### PR TITLE
Bump drift to 0.2.4; remove transition-tiling + cache-clear workarounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,21 +41,20 @@ actually populates for that group — not every species is modelled everywhere.
 
 ## Prerequisites (when running)
 
-Local `fwapg` (libpq env vars); `link` ≥ 0.44.0, `flooded`, `drift`, `fresh`; internet for the
-national MRDEM-30 (`flooded::fl_dem_aoi()`) and Microsoft Planetary Computer STAC.
+Local `fwapg` (libpq env vars); `link` ≥ 0.44.0, `flooded`, `drift` ≥ 0.2.4, `fresh`, `terra`
+≥ 1.8-10; internet for the national MRDEM-30 (`flooded::fl_dem_aoi()`) and Microsoft Planetary
+Computer STAC.
 
 ## Running gotchas (learned the hard way, issue #1)
 
-- **Clear the STAC cache between areas.** `drift::dft_stac_fetch` keys its cache on source+year only,
-  with no AOI — so a second area silently reuses the first area's rasters (drift#25). Run
-  `drift::dft_cache_clear(source = "io-lulc")` before each area's step 3 until drift is fixed.
-  Symptom when missed: implausibly low LULC change + classified coverage far below the floodplain.
-- **Large-extent floodplains OOM the transition vectorizer.** `drift::dft_transition_vectors`
-  processes the full raster grid once per transition class; a wide-bbox floodplain (e.g. UFRA,
-  ~103M cells) exhausts memory (drift#27). `fp_lulc` wraps it in `fp_transition_vectors_tiled`
-  (column-tiling; single-tile = identical output for small areas) as a stop-gap.
-- Both are "scales on small AOIs, breaks on large ones" — watch for the class when scaling to bigger
-  groups. Verify LULC by checking classified coverage ≈ floodplain area before trusting numbers.
+- **Two drift scaling bugs, both now FIXED — keep the verify-coverage habit.** `dft_stac_fetch`
+  used to key its cache on source+year only (no AOI), so a second area silently reused the first
+  area's rasters (drift#25, fixed in drift 0.2.3 — cache key now hashes the AOI). And
+  `dft_transition_vectors` used to process the full raster grid per transition class and OOM on
+  wide-bbox floodplains (drift#27, fixed in drift 0.2.4 — single `terra::patches()` pass, hence the
+  terra ≥ 1.8-10 floor). No more between-areas `dft_cache_clear` or driver-side tiling needed. But
+  the class of failure was "scales on small AOIs, breaks on large ones" — so still **verify LULC by
+  checking classified coverage ≈ floodplain area** before trusting numbers when scaling to new groups.
 - The single-outlet break point can fail `frs_watershed_split` at the exact WSG downstream tip
   (a boundary edge case); nudge one segment upstream on the mainstem and re-verify coverage.
 

--- a/scripts/floodplain_lcc/03_lulc_classify.R
+++ b/scripts/floodplain_lcc/03_lulc_classify.R
@@ -21,39 +21,6 @@
 #
 # Called by scripts/run_area.R (step 3). cfg comes from fp_read_config().
 
-# Memory-bounded transition vectorization.
-#
-# drift::dft_transition_vectors() processes the FULL raster grid once per transition
-# class (allocates rep(NA, ncell) vectors + runs terra::patches() per class). For a
-# large-extent floodplain (e.g. UFRA: ~103M-cell grid over a 119 km-wide bbox, 56
-# transition classes) that OOMs, even though only ~2% of cells hold data and trim()
-# can't shrink it (data follows the mainstem across the whole bbox). Here we split the
-# raster into column tiles so peak memory is bounded to one tile, vectorize each via
-# drift, and row-bind. Single tile (small areas) => one direct call => identical output
-# to the un-tiled path. Transition AREA is preserved (a patch split at a tile seam sums
-# across its pieces); only patch counts inflate slightly at seams. See drift issue on
-# dft_transition_vectors memory scaling.
-fp_transition_vectors_tiled <- function(x, zones, zone_col, max_cells = 25e6) {
-  if (terra::ncell(x) <= max_cells) {
-    return(dft_transition_vectors(x, zones = zones, zone_col = zone_col))
-  }
-  ntile <- ceiling(terra::ncell(x) / max_cells)
-  brks  <- unique(floor(seq(1, terra::ncol(x) + 1, length.out = ntile + 1)))
-  xmn <- terra::xmin(x); xres <- terra::xres(x)
-  parts <- list()
-  for (k in seq_len(length(brks) - 1L)) {
-    c0 <- brks[k]; c1 <- brks[k + 1L] - 1L
-    tile <- terra::crop(x, terra::ext(xmn + (c0 - 1L) * xres, xmn + c1 * xres,
-                                      terra::ymin(x), terra::ymax(x)))
-    if (all(is.na(terra::values(tile, mat = FALSE)))) next
-    v <- dft_transition_vectors(tile, zones = zones, zone_col = zone_col)
-    if (nrow(v) > 0) parts[[length(parts) + 1L]] <- v
-  }
-  if (length(parts) == 0) return(dft_transition_vectors(x[1, 1, drop = FALSE],
-                                                        zones = zones, zone_col = zone_col))
-  do.call(rbind, parts)
-}
-
 fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
   library(drift)
   library(sf)
@@ -137,7 +104,7 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
   # otherwise dominate as fragmented "Trees -> Trees" / "Water -> Water" pieces).
   if (nrow(trans_all$summary) > 0) {
     lyr <- paste0("transition_", scenario_id, "_2017_2023")
-    trans_polys <- fp_transition_vectors_tiled(
+    trans_polys <- dft_transition_vectors(
       trans_all$raster,
       zones = subbasins,
       zone_col = "name_basin"

--- a/scripts/packages.R
+++ b/scripts/packages.R
@@ -10,7 +10,7 @@ if (identical(getOption("repos")[["CRAN"]], "@CRAN@") ||
 if (!requireNamespace("pak", quietly = TRUE)) install.packages("pak")
 
 pkgs_cran <- c(
-  "sf", "terra", "stars",          # spatial
+  "sf", "terra", "stars",          # spatial (terra >= 1.8-10 for drift's transition patches fix)
   "DBI", "RPostgres",              # fwapg
   "here", "fs", "yaml",            # utils + config
   "dplyr", "readr", "stringr"
@@ -19,7 +19,7 @@ pkgs_cran <- c(
 pkgs_gh <- c(
   "newgraphenvironment/link",      # network extraction (>= 0.44.0 access fix)
   "newgraphenvironment/flooded",   # VCA floodplain delineation
-  "newgraphenvironment/drift",     # STAC LULC classify + transition
+  "newgraphenvironment/drift",     # STAC LULC classify + transition (>= 0.2.4: AOI cache key + single-pass transition, drift#25/#27)
   "newgraphenvironment/fresh"      # falls.csv + parameter CSVs (link engine)
 )
 


### PR DESCRIPTION
## Summary

First step of the scale-up (#3): now that `drift` 0.2.3/0.2.4 fix the two scaling bugs found during issue #1, bump `drift` and remove the driver-side workarounds so the pipeline runs clean and unattended over batches.

- **drift → 0.2.4** (drift#25 AOI cache key, drift#27 single-pass transition vectorizer).
- **Removed `fp_transition_vectors_tiled`** from `fp_lulc` → direct `dft_transition_vectors` call (drift's single `terra::patches()` pass handles UFRA's 102.6M-cell floodplain natively — 1.9 s vs the old OOM).
- `packages.R` notes `drift >= 0.2.4` + `terra >= 1.8-10` (the `patches(values=TRUE)` edge-wraparound floor); CLAUDE.md marks both gotchas fixed and keeps the verify-coverage habit.

## Verification

Ran `neexdzii` then `ufra` step 3 back-to-back with **no manual cache clear between** and **no tiling wrapper** (drift 0.2.4):

| Area | Floodplain | LULC coverage | Tree loss |
|---|---|---|---|
| Neexdzii | 171.0 km² | 104% (full) | **943.13 ha** (exact parity) |
| UFRA | 188.2 km² | **105% (full)** | 544.46 ha |

- Neexdzii tree loss is the exact known-good parity number → drift's transition rewrite is faithful (regression passes).
- UFRA full coverage immediately after Neexdzii proves the **#25** AOI cache key (cache holds both areas as distinct `2017_<hash>.nc` files — no collision).
- UFRA transition completed without OOM and without the tiling wrapper → **#27** single-pass fix confirmed.

Network (step 1, `link`) and floodplain (step 2, `flooded`) are untouched by the drift bump, so their parity stands from #1.

## Test plan
- [x] Neexdzii step 3 reproduces 943.13 ha tree loss + full coverage on drift 0.2.4
- [x] UFRA step 3 full coverage with no cache-clear-between + no tiling (drift#25/#27 fixes hold)
- [x] `03_lulc_classify.R` parses; no remaining `fp_transition_vectors_tiled` reference

## Notes

This unblocks the batch runner + Fraser pilot (the rest of #3): the pipeline no longer needs operational band-aids between areas. Next on #3: promote `run_areas.sh` to a multi-WSG driver and scaffold `stac_floodplains_bc` from `stac_airphoto_bc` (bucket via rtj#172).

Relates to #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh

Relates to NewGraphEnvironment/sred#35 (backfilled — R&D tracking)
