### PR TITLE
Make region runner resumable (skip completed groups)

### DIFF
--- a/scripts/run_region.R
+++ b/scripts/run_region.R
@@ -112,9 +112,18 @@ results <- list()
 for (i in seq_len(nrow(runnable))) {
   w <- runnable$wsg[i]; sp <- runnable$species[i]; area <- tolower(w)
   log <- file.path(log_dir, sprintf("region_%s_%s_%s.log", region, area, ts))
-  message("\n### ", w, " -> ", sp, " (steps ", steps, ") -> ", basename(log), " ###")
-  rc <- system2("Rscript", c(here::here("scripts", "run_area.R"), area, steps),
-                stdout = log, stderr = log)
+  # Resumable: a group whose lulc_summary.rds already exists is complete — skip it so a
+  # re-run after an interruption picks up where it left off. FORCE=1 redoes everything.
+  summary_rds <- file.path(here::here("data", area), "lulc_summary.rds")
+  cached <- file.exists(summary_rds) && !nzchar(Sys.getenv("FORCE"))
+  if (cached) {
+    message("\n### ", w, " -> ", sp, ": complete (lulc_summary.rds present) — SKIP (FORCE=1 to redo) ###")
+    rc <- 0L
+  } else {
+    message("\n### ", w, " -> ", sp, " (steps ", steps, ") -> ", basename(log), " ###")
+    rc <- system2("Rscript", c(here::here("scripts", "run_area.R"), area, steps),
+                  stdout = log, stderr = log)
+  }
   # POST-VERIFY: network non-empty (guards pre-pass-said-yes / run-gave-empty)
   km <- NA_real_; fp_km2 <- NA_real_
   net <- file.path(here::here("data", area), "aquatic_network.gpkg")
@@ -127,11 +136,11 @@ for (i in seq_len(nrow(runnable))) {
       if (!is.null(f)) fp_km2 <- sum(as.numeric(sf::st_area(f))) / 1e6
     }
   }
-  status <- if (rc != 0) "FAIL(run)" else if (is.na(km)) "FAIL(empty network)" else "ok"
-  if (status != "ok") message("  ⚠ ", w, ": ", status, " — see ", basename(log))
+  status <- if (rc != 0) "FAIL(run)" else if (is.na(km)) "FAIL(empty network)" else if (cached) "ok(cached)" else "ok"
+  if (!status %in% c("ok", "ok(cached)")) message("  ⚠ ", w, ": ", status, " — see ", basename(log))
   results[[i]] <- data.frame(wsg = w, species = sp, status = status,
                              network_km = round(km, 1), floodplain_km2 = round(fp_km2, 1),
-                             log = basename(log), stringsAsFactors = FALSE)
+                             log = if (cached) "" else basename(log), stringsAsFactors = FALSE)
 }
 
 # --- Coverage summary ---
@@ -142,5 +151,5 @@ csv <- file.path(log_dir, sprintf("region_%s_%s.csv", region, ts))
 readr::write_csv(summ, csv)
 message("\n=== Region ", region, " coverage ===")
 print(summ, row.names = FALSE)
-ok <- sum(summ$status == "ok")
-message(sprintf("\n%d/%d groups produced a floodplain. Summary: %s", ok, nrow(summ), csv))
+ok <- sum(summ$status %in% c("ok", "ok(cached)"))
+message(sprintf("\n%d/%d groups have a floodplain. Summary: %s", ok, nrow(summ), csv))


### PR DESCRIPTION
## Summary

Makes the region runner resumable so an interrupted batch picks up where it left off instead of redoing finished groups.

- A group whose `data/<wsg>/lulc_summary.rds` exists is complete → **SKIPPED** (`status ok(cached)`); `FORCE=1` redoes everything.
- The coverage summary counts cached + fresh groups.

## Why

The first Fraser batch was interrupted after 5 of 8 groups; this lets `run_region.R fraser` resume the remaining 3 in one command without recomputing the 5 done. Verified: the 5 completed groups skip instantly, NECR/MORK/FRAN queue to run.

## Note

The three remaining groups (NECR, MORK, FRAN — the largest floodplains) hit a **memory ceiling in drift's LULC step** on this 64 GB machine (NECR's 551 km² floodplain OOMs step 3 even solo). Filed **NewGraphEnvironment/drift#34** for the durable fix (window/block-process the transition/classify). The 5 completed groups are enough to proceed with the `stac_floodplains_bc` publish + QGIS round-trips; the big three get added once drift#34 lands (or on a higher-memory host).

Relates to #3
Relates to NewGraphEnvironment/sred#35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
