### PR TITLE
Add MCGR/BOWR + Peace (PCEA/PARS) areas; wire drift#36 tile_size opt-in + benchmark scaffold

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,9 @@ NECR, MORK, FRAN — 3,366 km² total floodplain, 15,022 ha gross tree loss (201
 
 ## Prerequisites (when running)
 
-Local `fwapg` (libpq env vars); `link` ≥ 0.44.0, `flooded`, `drift` ≥ 0.4.0, `fresh`, `terra`
+Local `fwapg` (libpq env vars); `link` ≥ 0.44.0, `flooded`, `drift` ≥ 0.6.0, `fresh`, `terra`
 ≥ 1.8-10; internet for the national MRDEM-30 (`flooded::fl_dem_aoi()`) and Microsoft Planetary
-Computer STAC.
+Computer STAC. (`drift` ≥ 0.6.0 because `fp_lulc` passes `tile_size` to `dft_stac_fetch`.)
 
 ## Running gotchas (learned the hard way, issue #1)
 
@@ -70,10 +70,13 @@ Computer STAC.
   The class of failure was "scales on small AOIs, breaks on large ones" — so still **verify LULC by
   checking classified coverage ≈ floodplain area** before trusting numbers when scaling to new groups.
 - **Wrap long runs in `caffeinate -s`.** The big-floodplain STAC fetch is ~30 min and download-bound
-  (it downloads the whole floodplain *bounding box* — ~10× the floodplain; the polygon-clip speedup
-  is drift#36, blocked upstream by gdalcubes#110). Long background jobs get killed by macOS idle
-  sleep — `caffeinate -s Rscript scripts/run_region.R <region>` (the resumable runner picks up any
-  interrupted group).
+  by default (it downloads the whole floodplain *bounding box* — ~10× the floodplain). drift 0.6.0
+  ships `dft_stac_fetch(tile_size=)` (drift#36) — the `filter_geom`-independent path that streams
+  only tiles intersecting the AOI, exposed as an **opt-in per-area `tile_size:` in `area.yml`**
+  (absent ⇒ unchanged bbox path). Speedup vs parity/accuracy is being benchmarked under issue #8
+  before broad adoption; the in-cube polygon-clip remains blocked upstream by gdalcubes#110. Long
+  background jobs get killed by macOS idle sleep — `caffeinate -s Rscript scripts/run_region.R
+  <region>` (the resumable runner picks up any interrupted group).
 
 ## Slash Command Configuration
 

--- a/config/bowr/area.yml
+++ b/config/bowr/area.yml
@@ -1,0 +1,6 @@
+name: bowr
+watershed_group: BOWR
+species: ch
+min_order: 3
+schema: bowr
+primary_scenario: ch_ff04

--- a/config/bowr/flood_scenarios.csv
+++ b/config/bowr/flood_scenarios.csv
@@ -1,0 +1,7 @@
+scenario_id,species,min_order,anchor_order,flood_factor,slope_threshold,max_width,cost_threshold,size_threshold,hole_threshold,lakes,wetlands,wetland_filter,run,description,ecological_process,citations
+ch_ff01,ch,3,1,1,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Bankfull channel extent,Active channel,
+ch_ff02,ch,3,1,2,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Flood-prone width / active channel margin,Active channel margin,
+ch_ff04,ch,3,1,4,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Functional floodplain,Functional floodplain,
+ch_ff06,ch,3,1,6,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Valley bottom extent,Valley bottom,
+ch_ff08,ch,3,1,8,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Extended valley - large wood recruitment,Extended valley / LWD recruitment,
+ch_ff12,ch,3,1,12,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Channel migration zone - full process width,Channel migration zone,

--- a/config/mcgr/area.yml
+++ b/config/mcgr/area.yml
@@ -1,0 +1,6 @@
+name: mcgr
+watershed_group: MCGR
+species: ch
+min_order: 3
+schema: mcgr
+primary_scenario: ch_ff04

--- a/config/mcgr/flood_scenarios.csv
+++ b/config/mcgr/flood_scenarios.csv
@@ -1,0 +1,7 @@
+scenario_id,species,min_order,anchor_order,flood_factor,slope_threshold,max_width,cost_threshold,size_threshold,hole_threshold,lakes,wetlands,wetland_filter,run,description,ecological_process,citations
+ch_ff01,ch,3,1,1,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Bankfull channel extent,Active channel,
+ch_ff02,ch,3,1,2,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Flood-prone width / active channel margin,Active channel margin,
+ch_ff04,ch,3,1,4,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Functional floodplain,Functional floodplain,
+ch_ff06,ch,3,1,6,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Valley bottom extent,Valley bottom,
+ch_ff08,ch,3,1,8,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Extended valley - large wood recruitment,Extended valley / LWD recruitment,
+ch_ff12,ch,3,1,12,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Channel migration zone - full process width,Channel migration zone,

--- a/config/pars/area.yml
+++ b/config/pars/area.yml
@@ -1,0 +1,6 @@
+name: pars
+watershed_group: PARS
+species: bt
+min_order: 3
+schema: pars
+primary_scenario: bt_ff04

--- a/config/pars/flood_scenarios.csv
+++ b/config/pars/flood_scenarios.csv
@@ -1,0 +1,7 @@
+scenario_id,species,min_order,anchor_order,flood_factor,slope_threshold,max_width,cost_threshold,size_threshold,hole_threshold,lakes,wetlands,wetland_filter,run,description,ecological_process,citations
+bt_ff01,bt,3,1,1,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Bankfull channel extent,Active channel,
+bt_ff02,bt,3,1,2,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Flood-prone width / active channel margin,Active channel margin,
+bt_ff04,bt,3,1,4,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Functional floodplain,Functional floodplain,
+bt_ff06,bt,3,1,6,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Valley bottom extent,Valley bottom,
+bt_ff08,bt,3,1,8,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Extended valley - large wood recruitment,Extended valley / LWD recruitment,
+bt_ff12,bt,3,1,12,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Channel migration zone - full process width,Channel migration zone,

--- a/config/pcea/area.yml
+++ b/config/pcea/area.yml
@@ -1,0 +1,6 @@
+name: pcea
+watershed_group: PCEA
+species: bt
+min_order: 3
+schema: pcea
+primary_scenario: bt_ff04

--- a/config/pcea/flood_scenarios.csv
+++ b/config/pcea/flood_scenarios.csv
@@ -1,0 +1,7 @@
+scenario_id,species,min_order,anchor_order,flood_factor,slope_threshold,max_width,cost_threshold,size_threshold,hole_threshold,lakes,wetlands,wetland_filter,run,description,ecological_process,citations
+bt_ff01,bt,3,1,1,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Bankfull channel extent,Active channel,
+bt_ff02,bt,3,1,2,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Flood-prone width / active channel margin,Active channel margin,
+bt_ff04,bt,3,1,4,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Functional floodplain,Functional floodplain,
+bt_ff06,bt,3,1,6,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Valley bottom extent,Valley bottom,
+bt_ff08,bt,3,1,8,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Extended valley - large wood recruitment,Extended valley / LWD recruitment,
+bt_ff12,bt,3,1,12,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Channel migration zone - full process width,Channel migration zone,

--- a/config/regions/peace.yml
+++ b/config/regions/peace.yml
@@ -1,0 +1,14 @@
+# Peace region — Peace/Parsnip drainage (Arctic slope). Bull trout is the target species:
+# chinook do not occur above the Fraser divide, so `ch` is unmodelled here (access_ch = 0)
+# and `bt` carries the network. Same whole-WSG treatment as the Fraser groups (no
+# break_points.csv => the FWA group polygon is the single sub-basin).
+#
+# PINE (Pine River) belongs to this region but is NOT yet loaded in the local fwapg build
+# (0 segments in fresh.streams_vw_bcfp) — add it here after a link/bcfishpass build loads it.
+# The pre-pass will loudly SKIP any listed group with no modelled network, so PINE can be
+# added now and will simply be reported as SKIPPED until the data exists.
+region: peace
+mergin_project: TBD              # doc-only; set when a Peace field project exists
+min_order: 3
+species: [bt]                    # bull trout only (ch unmodelled on the Arctic slope)
+watershed_groups: [PCEA, PARS]   # PINE pending a link build

--- a/planning/active/findings.md
+++ b/planning/active/findings.md
@@ -1,0 +1,57 @@
+# Findings — #8 tiled STAC fetch
+
+## Package audit (2026-07-11)
+- `flooded` 0.3.2 = origin/main; **unchanged** since the last WSG run. Local checkout clean.
+- `drift` installed 0.4.0 while origin was **0.6.0** (local checkout was 65 behind). Updated to
+  0.6.0 from the fast-forwarded checkout.
+- Changes since last run (0.4.0 -> 0.6.0):
+  - **0.5.0** `dft_stac_cube(clip=)` — continuous Sentinel-2 *trajectory* path; `fp_lulc` does not
+    use it. No effect on categorical LULC runs.
+  - **0.6.0** `dft_stac_fetch(tile_size=)` — the categorical path `fp_lulc` uses. Default `NULL` =
+    old behavior. This is the actionable change.
+- `dft_rast_transition` / `dft_transition_vectors` signatures unchanged (0.4.0 `changes_only`
+  path intact) — verified via `args()`.
+
+## `tile_size` mechanics (drift NEWS 0.6.0)
+- Splits the bbox into a `res`-aligned grid, streams only tiles intersecting the AOI polygon,
+  mosaics with `terra::merge()`. `filter_geom`-independent (the in-cube clip segfaults on the
+  pinned gdalcubes build; still blocked by gdalcubes#110).
+- Tiled fetches cache a terra GeoTIFF (`.tif`) and key distinctly from untiled NetCDF (`.nc`) —
+  so enabling it re-fetches once but leaves existing untiled caches intact. `tile_size = NULL`
+  is byte-for-byte previous behavior.
+- Smaller tiles waste less bbox but cost more per-tile round trips; no auto-tuning.
+- CRS units = metres under the default UTM CRS.
+
+## Integration decision
+- Opt-in via `area.yml` `tile_size:` (NULL default) rather than a global flip: protects the
+  neexdzii **943.13 ha** parity gate and the already-published Fraser groups, which would
+  otherwise re-fetch on the tiled path and could differ at mosaic seams.
+- Both `fp_lulc` fetch sites take it: whole-floodplain (L68) and per-sub-basin (L149). For a
+  whole-WSG group the per-sub-basin AOI ≈ the whole floodplain (one group-polygon sub-basin),
+  so both are large and both benefit.
+
+## Plan-agent review (2026-07-11, pre-baseline)
+Caught before the baseline commit — fixes folded in:
+- **Blocker: no runtime drift floor.** `tile_size` is passed unconditionally, so drift < 0.6.0
+  errors "unused argument" for every area; `update_packages` defaults FALSE and packages.R had
+  no pin. Fix: `fp_lulc` asserts `packageVersion("drift") >= 0.6.0`; packages.R comment bumped.
+- **Blocker: "clear cache between runs" clobbers the shared cache** (`cache_dir = NULL` =>
+  one `user_cache_dir("drift")`). Tiled `.tif` / untiled `.nc` key distinctly and never collide,
+  so use `force = TRUE`, never a cache wipe. Plan + memo corrected.
+- **Gap: no revert-proof way to run the fixture tiled.** `tile_size` came only from `area.yml`;
+  editing `config/neexdzii/area.yml` risks committing it into the parity fixture. Fix: `FP_TILE_SIZE`
+  env override in `fp_read_config`.
+- **Gap: neexdzii is a compact reach** — weak seam test. Accuracy must additionally run on a
+  whole-WSG corridor (PCEA). Parity stays neexdzii (that's where 943.13 ha lives).
+- **Acceptance: parity tolerance mis-scaled** — the 1 ha sieve means a seam pixel can swing ~1 ha,
+  ~25× the 0.004% VCA figure. Judge parity at ~1 ha, downstream of the pre-sieve accuracy metric.
+  Added numeric floors (accuracy ≥ 99.9% no seam band; speedup ≥ 2×).
+- **Scope:** adopt on benchmarked group(s) first; extend to same-geometry corridors only with the
+  generalization stated + per-group coverage check.
+- Verified OK: opt-in NULL path sound; CRS fine (drift auto-UTM, `tile_size` metres align `res=10`).
+
+## New-area coverage checks (context, landed under #3)
+- MCGR ch=4087 / bt=4884 · BOWR ch=3335 / bt=3807 — chinook chosen (Fraser drainage).
+- PCEA ch=0 / bt=6988 · PARS ch=0 / bt=8436 — bull trout only (Arctic slope).
+- **PINE = 0 segments for both** — not a species gap; PINE is not loaded in the local fwapg
+  build. Blocked until a link/bcfishpass build loads it.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -1,0 +1,14 @@
+# Progress — #8 tiled STAC fetch
+
+## Session 2026-07-11
+- Audited packages: `flooded` 0.3.2 unchanged; `drift` 0.4.0 -> 0.6.0 (installed + local ff'd).
+- Wired `tile_size` opt-in into `fp_lulc` (both fetch sites) + documented the `area.yml` key in
+  `fp_read_config`; bumped drift floor >= 0.6.0 and refreshed the CLAUDE.md gotcha.
+- Established evidence structure: `research/` (README + dated benchmark memo) and
+  `scripts/floodplain_lcc/logs/` (README).
+- Landed alongside under #3: MCGR + BOWR chinook areas, Peace region (PCEA + PARS bull trout);
+  PINE flagged pending a link build.
+- Commits: cc51ee8 (MCGR+BOWR), d05761c (Peace/PCEA/PARS), b0ecb00 (tile_size wiring + docs),
+  + this PWF baseline.
+- Next: Phase 2 — run neexdzii both ways for the parity gate (943.13 ha), then accuracy +
+  speedup on PCEA/PARS. Needs local fwapg + `caffeinate -s`.

--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -8,7 +8,13 @@
   `scripts/floodplain_lcc/logs/` (README).
 - Landed alongside under #3: MCGR + BOWR chinook areas, Peace region (PCEA + PARS bull trout);
   PINE flagged pending a link build.
+- Plan-agent review before baseline caught 2 blockers (no runtime drift floor; cache-wipe would
+  clobber the shared cache) + gaps (fixture-tiling injection path, accuracy subject, parity
+  tolerance, thresholds) — all folded in. See findings.md.
 - Commits: cc51ee8 (MCGR+BOWR), d05761c (Peace/PCEA/PARS), b0ecb00 (tile_size wiring + docs),
-  + this PWF baseline.
-- Next: Phase 2 — run neexdzii both ways for the parity gate (943.13 ha), then accuracy +
-  speedup on PCEA/PARS. Needs local fwapg + `caffeinate -s`.
+  03bf025 (plan-review hardening: drift>=0.6.0 assert + FP_TILE_SIZE override), eae82a3 (this
+  PWF + research/ + logs/ baseline).
+- Branch `8-tile-fetch-benchmark`, not yet pushed.
+- Next: Phase 2 — generate PCEA steps 1,2; run neexdzii step 3 both ways for the ~1 ha parity
+  gate (untiled must hold 943.13 ha); accuracy on PCEA corridor; speedup direct-time. Needs
+  local fwapg + `caffeinate -s`.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -1,0 +1,67 @@
+# Task Plan — Tiled STAC fetch (`tile_size`): integrate + benchmark (#8)
+
+Wire drift 0.6.0's `dft_stac_fetch(tile_size=)` (drift#36) into `fp_lulc` as an opt-in
+per-area knob, then benchmark speedup vs parity vs accuracy before adopting it broadly.
+Method stays in `drift`; this repo only exposes the knob and gathers the evidence.
+
+## Phase 1: Integrate as opt-in
+- [x] Update `flooded` / `drift` to latest; confirm `flooded` 0.3.2 unchanged, `drift` 0.4.0 -> 0.6.0.
+- [x] Pass `tile_size = cfg$tile_size` at both `dft_stac_fetch` sites in `03_lulc_classify.R`
+      (whole floodplain + per-sub-basin). Absent from `area.yml` => NULL => unchanged path.
+- [x] Document the optional `tile_size:` key in `fp_read_config`; bump drift floor to >= 0.6.0
+      and refresh the drift#36 gotcha note in CLAUDE.md.
+- [x] Establish evidence structure: `research/` (durable memo) + `scripts/floodplain_lcc/logs/`
+      (committed benchmark logs); leave `data/logs/` for gitignored bulk output.
+- [x] Plan-review hardening: `fp_lulc` asserts `drift >= 0.6.0` (fail loud — the unconditional
+      `tile_size` arg breaks EVERY area on older drift, and `update_packages` defaults FALSE);
+      `FP_TILE_SIZE` env override in `fp_read_config` (revert-proof fixture tiling); packages.R
+      floor comment bumped.
+
+## Phase 2: Benchmark (the SRED experiment)
+
+Cache hygiene (both blockers from plan review): drift's cache is one shared dir
+(`cache_dir = NULL` => `user_cache_dir("drift")`). **Never delete it** — that would destroy
+every published group's `.nc` cache. Tiled (`.tif`) and untiled (`.nc`) key distinctly and
+never collide, so re-download for timing uses `force = TRUE` on a direct `dft_stac_fetch`
+call, not a cache wipe. Tile the fixture via the `FP_TILE_SIZE` env var, never by editing
+`config/neexdzii/area.yml`.
+
+- [ ] **Prereq — AOIs exist.** neexdzii outputs are present; generate PCEA (and PARS) steps 1–2
+      first (`run_area.R <wsg> 1,2`) so `floodplain.gpkg`/`subbasins.gpkg` exist. This is
+      long-running and is NOT part of the fetch timing.
+- [ ] **Parity (go/no-go anchor)** — run `neexdzii` step 3 untiled, then tiled via
+      `FP_TILE_SIZE=<m> Rscript scripts/run_area.R neexdzii 3`. Pass = tiled `co_ff04` tree-loss
+      equals untiled within **one patch-sieve unit (~1 ha)** — the tolerance is patch-quantized,
+      NOT the 0.004% VCA figure: post-sieve (`patch_min_m2 = 10000`) a single seam pixel near a
+      1 ha patch boundary can add/drop a whole patch. Untiled must still reproduce 943.13 ha.
+- [ ] **Accuracy (the real seam test)** — on a **whole-WSG corridor** (PCEA — the adoption
+      target, many interior `terra::merge()` seams; neexdzii is a compact reach and under-tests
+      seams), compare classified rasters (pre-sieve) tiled-mosaic vs untiled+clip **inside the
+      polygon**. Pass = **≥ 99.9% pixel agreement and no systematic seam band** (disagreement
+      not aligned to tile edges). This is the metric that actually rules out the mosaic risk.
+- [ ] **Speedup** — direct-time `dft_stac_fetch` untiled vs `tile_size` 5000 / 10000 m on
+      PCEA's floodplain, `force = TRUE` each, no cache wipe; record wall-clock ratio.
+- [ ] Write measurements to `scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_<wsg>.md`.
+
+## Phase 3: Decide + document
+- [ ] Populate the `research/` memo Results + Decision from the logs.
+- [ ] Adopt only if **all three** hold: parity within ~1 ha, accuracy ≥ 99.9% with no seam band,
+      speedup ≥ 2×. Set `tile_size:` in the **benchmarked** large group(s) first (PCEA/PARS).
+- [ ] Extend to same-geometry whole-WSG corridors (MCGR, BOWR) **only** with the generalization
+      stated (seams are corridor-geometry-dependent), and per-group `verify classified coverage
+      ≈ floodplain area` before trusting numbers. Fixture + published groups stay on default.
+- [ ] If accuracy shows seams or parity fails: keep opt-in off, record why in the memo.
+
+## Validation
+- [ ] neexdzii untiled reproduces 943.13 ha AND tiled passes the ~1 ha parity gate before any
+      group adopts `tile_size`.
+- [ ] Accuracy floor (≥ 99.9%, no seam band) met on the whole-WSG corridor, not only the reach.
+- [ ] Shared drift cache never deleted during benchmarking (published caches intact).
+- [ ] `/code-check` clean on each commit; PWF checkboxes match landed work.
+- [ ] `/planning-archive` on completion.
+
+## Out of scope
+- The new-area configs (MCGR, BOWR / Peace PCEA, PARS) landed alongside under #3 — they
+  provide the large whole-WSG floodplains this benchmark measures on, but adding areas is
+  not this issue's concern.
+- PINE — blocked on a link/bcfishpass build (0 segments in fwapg); tracked in `peace.yml`.

--- a/research/20260711_lulc_tile-fetch-benchmark.md
+++ b/research/20260711_lulc_tile-fetch-benchmark.md
@@ -1,0 +1,47 @@
+# Tiled STAC fetch (`tile_size`) — speedup vs parity vs accuracy
+
+**Date opened:** 2026-07-11 · **Issue:** #8 · **drift:** 0.6.0 (`dft_stac_fetch(tile_size=)`,
+drift#36) · **Status:** OPEN — design set, runs pending.
+
+## Hypothesis
+
+`dft_stac_fetch` streams the whole floodplain **bounding box**; for a thin, diagonal whole-WSG
+floodplain corridor that is ~10× the pixels inside the polygon. Setting `tile_size` streams only
+tiles intersecting the AOI, mosaicked with `terra::merge()` → close to footprint. Expectation:
+**large wall-clock reduction on the download-bound fetch, with land-cover output unchanged inside
+the polygon.** The uncertainty worth investigating: does the tiled mosaic preserve classification
+accuracy (no `terra::merge()` seam artifacts), and does it hold the known-good parity number?
+
+## Method
+
+| Axis | Subject | Test | Pass criterion |
+|---|---|---|---|
+| **Parity** | neexdzii (known-good anchor) | step 3 untiled vs tiled (via `FP_TILE_SIZE`) | untiled reproduces `co_ff04` **943.13 ha**; tiled within **~1 ha** of untiled |
+| **Accuracy** | PCEA (whole-WSG corridor) | classified rasters (pre-sieve) tiled-mosaic vs untiled+clip, inside polygon | **≥ 99.9%** pixel agreement, **no seam band** aligned to tile edges |
+| **Speedup** | PCEA floodplain | direct-time `dft_stac_fetch` untiled vs `tile_size` 5000 / 10000 m, `force = TRUE` | **≥ 2×** wall-clock; record ratio |
+
+Why two subjects: neexdzii is a compact reach (few/no interior seams) so its parity is
+*necessary but weak* on the mosaic risk — it anchors the number. The seam risk only shows on a
+thin diagonal whole-WSG corridor (PCEA), which is also the adoption target. Both are needed.
+
+**Parity tolerance is patch-quantized, not the 0.004% VCA figure.** Tree-loss is computed after
+the 1 ha patch sieve (`patch_min_m2 = 10000`), so a single seam pixel near a patch boundary can
+add/drop a whole ≥1 ha patch — a swing ~25× the raw VCA noise. Judge parity at ~1 ha, and read
+it downstream of the pre-sieve accuracy metric.
+
+**Cache hygiene.** drift's cache is one shared dir (`cache_dir = NULL`). It is NEVER deleted
+during benchmarking — that would destroy every published group's `.nc` cache. Tiled (`.tif`) and
+untiled (`.nc`) key distinctly and never collide, so timing re-downloads use `force = TRUE`.
+
+Raw timings/coverage → committed evidence logs under `scripts/floodplain_lcc/logs/`
+(`yyyymmdd_lulc_tile-benchmark_<wsg>.md`). This memo records the distilled verdict.
+
+## Results
+
+_TBD — populated after the runs._
+
+## Decision
+
+_TBD._ If accuracy + parity hold: adopt `tile_size` per-area for large whole-WSG floodplains
+(set `tile_size:` in their `area.yml`), leaving the parity fixture + published groups on the
+default path. If seams degrade accuracy: keep opt-in off and record why.

--- a/research/README.md
+++ b/research/README.md
@@ -1,0 +1,13 @@
+# research
+
+Durable synthesis memos for method-evaluation experiments — the SRED-facing "what did we
+learn and what did we decide" layer that outlives any single issue's planning archive.
+
+- One dated memo per investigation: `yyyymmdd_noun_verb-detail.md`.
+- The memo carries the **hypothesis, method, results, and decision** in one place, and cites
+  the committed evidence logs (`scripts/<module>/logs/`) that hold the raw measurements.
+- The per-issue **PWF** (`planning/`) holds the iteration/uncertainty narrative; this dir
+  holds the distilled verdict so it stays browsable after the PWF is archived.
+
+Three homes, each one job: **PWF = the story, `scripts/<module>/logs/` = the measurements,
+`research/` = the durable verdict.**

--- a/scripts/floodplain_lcc/03_lulc_classify.R
+++ b/scripts/floodplain_lcc/03_lulc_classify.R
@@ -27,6 +27,15 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
   library(terra)
   library(dplyr)
 
+  # fp_lulc passes tile_size to dft_stac_fetch unconditionally (NULL = off), a param that
+  # only exists in drift >= 0.6.0 — on an older drift the call errors with "unused argument"
+  # for EVERY area, tiled or not. update_packages defaults FALSE, so guard loudly here.
+  if (utils::packageVersion("drift") < "0.6.0") {
+    stop("fp_lulc requires drift >= 0.6.0 (dft_stac_fetch tile_size); installed ",
+         as.character(utils::packageVersion("drift")),
+         ". Update: pak::pak('newgraphenvironment/drift')", call. = FALSE)
+  }
+
   sf::sf_use_s2(FALSE)
   terra::terraOptions(threads = 12)
 

--- a/scripts/floodplain_lcc/03_lulc_classify.R
+++ b/scripts/floodplain_lcc/03_lulc_classify.R
@@ -64,8 +64,14 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
   # Use name_basin from break_points (carried through via fresh::frs_watershed_split)
 
   # --- Pass 1: Whole floodplain (for interactive map) ---
+  # tile_size (drift#36, opt-in via area.yml; NULL = off) bounds the STAC download to
+  # tiles intersecting the AOI instead of the whole floodplain bounding box (~10x the
+  # polygon for a thin corridor). Left NULL for the parity fixture + already-published
+  # groups so their fetch path is byte-for-byte unchanged; set per-area for large
+  # whole-WSG floodplains where the bbox waste dominates the ~30 min fetch.
   message("=== Whole floodplain ===")
-  rasters_all <- dft_stac_fetch(floodplain, source = "io-lulc", years = years)
+  rasters_all <- dft_stac_fetch(floodplain, source = "io-lulc", years = years,
+                                tile_size = cfg$tile_size)
   classified_all <- dft_rast_classify(rasters_all, source = "io-lulc")
   trans_all <- dft_rast_transition(
     classified_all, from = "2017", to = "2023",
@@ -146,7 +152,8 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
     }
 
     message("Processing: ", lab)
-    rasters <- dft_stac_fetch(fp_clip, source = "io-lulc", years = years)
+    rasters <- dft_stac_fetch(fp_clip, source = "io-lulc", years = years,
+                              tile_size = cfg$tile_size)
     classified <- dft_rast_classify(rasters, source = "io-lulc")
     summary <- dft_rast_summarize(classified, unit = "ha")
     summary$name_basin <- lab

--- a/scripts/floodplain_lcc/logs/README.md
+++ b/scripts/floodplain_lcc/logs/README.md
@@ -1,0 +1,15 @@
+# logs
+
+Committed **evidence logs** for the floodplain pipeline — dated benchmark/timing/coverage runs
+that are R&D evidence (one per intentional run):
+
+    yyyymmdd_noun_verb-detail_target.ext
+
+e.g. `20260711_lulc_tile-benchmark_pcea.md`. Committed to the default branch so git carries the
+provenance (the log sits next to the change that produced it) and it is discoverable cross-machine
+via the GitHub API without cloning.
+
+**Not** for bulk machine output — per-WSG region CSVs, aborted/offline reruns, and other
+pipeline-emitted iteration dumps stay in the gitignored `data/logs/`. Rule of thumb: if you'd hand
+it to an auditor as proof of an experiment, it lives here; if it's hundreds of files a pipeline
+emitted, it stays under `data/`.

--- a/scripts/packages.R
+++ b/scripts/packages.R
@@ -19,7 +19,7 @@ pkgs_cran <- c(
 pkgs_gh <- c(
   "newgraphenvironment/link",      # network extraction (>= 0.44.0 access fix)
   "newgraphenvironment/flooded",   # VCA floodplain delineation
-  "newgraphenvironment/drift",     # STAC LULC classify + transition (>= 0.4.0: changes_only bounds large-floodplain memory, drift#25/#27/#34)
+  "newgraphenvironment/drift",     # STAC LULC classify + transition (>= 0.6.0: dft_stac_fetch tile_size, drift#36; fp_lulc asserts this floor)
   "newgraphenvironment/fresh"      # falls.csv + parameter CSVs (link engine)
 )
 

--- a/scripts/run_area.R
+++ b/scripts/run_area.R
@@ -48,6 +48,11 @@ fp_read_config <- function(area) {
   # tile_size: OPTIONAL area.yml key (CRS metres). Absent => cfg$tile_size is NULL =>
   # fp_lulc fetches the whole floodplain bbox (unchanged). Set it to bound the STAC
   # download to the AOI footprint on large whole-WSG floodplains (drift#36).
+  # FP_TILE_SIZE env var overrides area.yml at runtime WITHOUT editing a committed config —
+  # so the neexdzii parity fixture can be run tiled for the #8 benchmark and reverted by
+  # unsetting the var, never risking a committed tile_size in the fixture. Empty => no override.
+  env_tile <- Sys.getenv("FP_TILE_SIZE", "")
+  if (nzchar(env_tile)) cfg$tile_size <- as.numeric(env_tile)
   cfg
 }
 

--- a/scripts/run_area.R
+++ b/scripts/run_area.R
@@ -45,6 +45,9 @@ fp_read_config <- function(area) {
   fs::dir_create(cfg$dir_out)
 
   if (is.null(cfg$primary_scenario)) cfg$primary_scenario <- "co_ff04"
+  # tile_size: OPTIONAL area.yml key (CRS metres). Absent => cfg$tile_size is NULL =>
+  # fp_lulc fetches the whole floodplain bbox (unchanged). Set it to bound the STAC
+  # download to the AOI footprint on large whole-WSG floodplains (drift#36).
   cfg
 }
 


### PR DESCRIPTION
## Summary

Groundwork for scaling to the Peace and additional upper-Fraser groups, plus an opt-in
faster STAC fetch — all default-safe (no existing run changes behaviour).

- **New area configs.** MCGR + BOWR (chinook, upper Fraser) and a new Peace region
  (`config/regions/peace.yml`) with PCEA + PARS (bull trout — chinook is unmodelled on the
  Arctic slope). Species coverage verified against `fresh.streams_vw_bcfp` at order >= 3. PINE
  belongs to the Peace region but is not yet loaded in fwapg (0 segments) — documented as
  pending a link build; the pre-pass reports it SKIPPED until then.
- **drift#36 `tile_size` opt-in.** `fp_lulc` passes `tile_size = cfg$tile_size` to both
  `dft_stac_fetch` sites, bounding the download to the AOI footprint instead of the whole
  floodplain bounding box (~10x the polygon). Opt-in via an `area.yml` key; absent => `NULL`
  => byte-for-byte the old path, so the neexdzii parity fixture and the published Fraser groups
  are untouched. drift floor bumped to >= 0.6.0 with a fail-loud runtime assert; `FP_TILE_SIZE`
  env override lets the fixture be run tiled for benchmarking without a committed config edit.
- **Evidence structure for the benchmark.** `research/` (durable synthesis memos) and
  `scripts/floodplain_lcc/logs/` (committed, dated evidence logs), plus the issue #8 PWF. A
  plan-agent review before baseline caught two blockers (no runtime drift floor; a cache wipe
  that would clobber the shared drift cache) and several gaps — all folded in.

Capability is shipped but **not yet adopted**: no group sets `tile_size:`. Turning it on is
gated on the speedup/parity/accuracy benchmark, which lands as a follow-up PR that closes #8.

## Related Issues
- Relates to #3 (multi-WSG scale + publish)
- Relates to #8 (tile_size integration + benchmark; stays open for Phase 2 results)
- Relates to NewGraphEnvironment/sred#35

## Test plan
- [x] All edited scripts parse (`03_lulc_classify.R`, `run_area.R`, `packages.R`)
- [x] Species coverage verified for all four groups (order >= 3, `fresh.streams_vw_bcfp`)
- [x] Configs generated via `run_region.R` pre-pass — identical shape to the Fraser-8
- [ ] Phase 2 benchmark (separate PR): neexdzii parity 943.13 ha, PCEA accuracy + speedup

## Notes
Default path is unchanged; this PR ships the knob and the groundwork, not the decision to use
it. Adoption + benchmark evidence come in the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
