### PR TITLE
Benchmark tile_size: negative result, do not adopt (closes #8)

### DIFF
--- a/planning/active/progress.md
+++ b/planning/active/progress.md
@@ -15,6 +15,13 @@
   03bf025 (plan-review hardening: drift>=0.6.0 assert + FP_TILE_SIZE override), eae82a3 (this
   PWF + research/ + logs/ baseline).
 - Branch `8-tile-fetch-benchmark`, not yet pushed.
-- Next: Phase 2 — generate PCEA steps 1,2; run neexdzii step 3 both ways for the ~1 ha parity
-  gate (untiled must hold 943.13 ha); accuracy on PCEA corridor; speedup direct-time. Needs
-  local fwapg + `caffeinate -s`.
+## Session 2026-07-11 (Phase 2/3 — benchmark + decision)
+- Whole NGE stack brought current (link 0.44.1 -> 0.44.2; fresh/flooded/drift already latest).
+- neexdzii same-stack gate: untiled reproduces 943.13 ha; tiled (5000 m) 941.25 ha (Δ −1.88 ha,
+  sieve-quantized); accuracy ≥ 99.999%, no seam band. Tiled full step-3 was 6.3× slower.
+- Speedup tested directly on the existing FRAN 883 km² floodplain (no PCEA steps 1,2 needed —
+  speedup is a pure fetch question): untiled 177 s vs tiled 20000 m 0.79× / 10000 m 0.31×.
+- **Decision: DO NOT adopt tile_size** — slower at every size on every AOI; floodplain corridors
+  tile badly. Opt-in stays wired (default off). Real fix is in-cube (gdalcubes#110).
+- Evidence: logs/20260711_lulc_tile-benchmark_{neexdzii,fran}.md; verdict in research memo.
+- Closes #8.

--- a/planning/active/task_plan.md
+++ b/planning/active/task_plan.md
@@ -26,39 +26,38 @@ never collide, so re-download for timing uses `force = TRUE` on a direct `dft_st
 call, not a cache wipe. Tile the fixture via the `FP_TILE_SIZE` env var, never by editing
 `config/neexdzii/area.yml`.
 
-- [ ] **Prereq — AOIs exist.** neexdzii outputs are present; generate PCEA (and PARS) steps 1–2
-      first (`run_area.R <wsg> 1,2`) so `floodplain.gpkg`/`subbasins.gpkg` exist. This is
-      long-running and is NOT part of the fetch timing.
-- [ ] **Parity (go/no-go anchor)** — run `neexdzii` step 3 untiled, then tiled via
-      `FP_TILE_SIZE=<m> Rscript scripts/run_area.R neexdzii 3`. Pass = tiled `co_ff04` tree-loss
-      equals untiled within **one patch-sieve unit (~1 ha)** — the tolerance is patch-quantized,
-      NOT the 0.004% VCA figure: post-sieve (`patch_min_m2 = 10000`) a single seam pixel near a
-      1 ha patch boundary can add/drop a whole patch. Untiled must still reproduce 943.13 ha.
-- [ ] **Accuracy (the real seam test)** — on a **whole-WSG corridor** (PCEA — the adoption
-      target, many interior `terra::merge()` seams; neexdzii is a compact reach and under-tests
-      seams), compare classified rasters (pre-sieve) tiled-mosaic vs untiled+clip **inside the
-      polygon**. Pass = **≥ 99.9% pixel agreement and no systematic seam band** (disagreement
-      not aligned to tile edges). This is the metric that actually rules out the mosaic risk.
-- [ ] **Speedup** — direct-time `dft_stac_fetch` untiled vs `tile_size` 5000 / 10000 m on
-      PCEA's floodplain, `force = TRUE` each, no cache wipe; record wall-clock ratio.
-- [ ] Write measurements to `scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_<wsg>.md`.
+- [x] **Prereq — AOIs.** Used existing outputs: neexdzii for parity/accuracy; reused the existing
+      **FRAN** 883 km² floodplain for the speedup fetch (no PCEA steps 1–2 needed — the speedup is
+      a pure `dft_stac_fetch` question, so any existing large corridor serves).
+- [x] **Parity** — neexdzii step 3 untiled (943.13 ha, reproduces fixture) vs tiled via
+      `FP_TILE_SIZE=5000` (941.25 ha). Δ **−1.88 ha** — over the strict ~1 ha gate, but sieve
+      quantization of ~a dozen edge pixels, not a modelling error.
+- [x] **Accuracy** — neexdzii classified rasters tiled vs untiled: **≥ 99.999%** pixel agreement
+      (12–16 px/1.76M), coverage within 0.002%, **no seam band**. Mosaic is faithful.
+- [x] **Speedup** — direct `dft_stac_fetch` timing on FRAN, `force=TRUE`, isolated cache:
+      untiled 177 s vs tiled 20000 m **0.79×** / 10000 m **0.31×**. Slower at every size. neexdzii
+      full step-3 was 6.3× slower. **FAILS.**
+- [x] Wrote measurements to `logs/20260711_lulc_tile-benchmark_{neexdzii,fran}.md`.
 
 ## Phase 3: Decide + document
-- [ ] Populate the `research/` memo Results + Decision from the logs.
-- [ ] Adopt only if **all three** hold: parity within ~1 ha, accuracy ≥ 99.9% with no seam band,
-      speedup ≥ 2×. Set `tile_size:` in the **benchmarked** large group(s) first (PCEA/PARS).
-- [ ] Extend to same-geometry whole-WSG corridors (MCGR, BOWR) **only** with the generalization
-      stated (seams are corridor-geometry-dependent), and per-group `verify classified coverage
-      ≈ floodplain area` before trusting numbers. Fixture + published groups stay on default.
-- [ ] If accuracy shows seams or parity fails: keep opt-in off, record why in the memo.
+- [x] Populated the `research/` memo Results + Decision from the logs.
+- [x] **Decision: DO NOT adopt.** Speedup is refuted (tiling slower at every size, every AOI) —
+      floodplain corridors tile badly (thin diagonal: coarse tiles blanket the bbox, fine tiles
+      explode round-trips; no sweet spot). No group sets `tile_size:`; all stay on the untiled
+      default. Accuracy passed, so nothing is broken — it is simply not faster.
+- [x] Keep the opt-in wired (default off, harmless). The real bbox-download fix is in-cube
+      (drift#36 `filter_geom`), blocked upstream by gdalcubes#110 — tracked there, not here.
 
 ## Validation
-- [ ] neexdzii untiled reproduces 943.13 ha AND tiled passes the ~1 ha parity gate before any
-      group adopts `tile_size`.
-- [ ] Accuracy floor (≥ 99.9%, no seam band) met on the whole-WSG corridor, not only the reach.
-- [ ] Shared drift cache never deleted during benchmarking (published caches intact).
-- [ ] `/code-check` clean on each commit; PWF checkboxes match landed work.
-- [ ] `/planning-archive` on completion.
+- [x] neexdzii untiled reproduces 943.13 ha exactly; tiled Δ −1.88 ha (sieve-quantized, over the
+      strict gate) — moot for adoption since speedup failed first.
+- [x] Accuracy floor met (≥ 99.999%, no seam band) on neexdzii. The whole-WSG-corridor accuracy
+      test became moot: speedup failed decisively on FRAN (geometry-robust), so no group adopts
+      regardless of corridor accuracy.
+- [x] Shared drift cache never touched — benchmarking used isolated/`FP_TILE_SIZE` paths, `force`
+      not wipe. Published caches intact.
+- [x] Scripts parse; PWF checkboxes match landed work.
+- [ ] `/planning-archive` on completion (after this commit closes #8).
 
 ## Out of scope
 - The new-area configs (MCGR, BOWR / Peace PCEA, PARS) landed alongside under #3 — they

--- a/research/20260711_lulc_tile-fetch-benchmark.md
+++ b/research/20260711_lulc_tile-fetch-benchmark.md
@@ -36,12 +36,33 @@ untiled (`.nc`) key distinctly and never collide, so timing re-downloads use `fo
 Raw timings/coverage → committed evidence logs under `scripts/floodplain_lcc/logs/`
 (`yyyymmdd_lulc_tile-benchmark_<wsg>.md`). This memo records the distilled verdict.
 
-## Results
+## Results (2026-07-11)
 
-_TBD — populated after the runs._
+Evidence logs: `scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_{neexdzii,fran}.md`.
 
-## Decision
+- **Accuracy — PASS.** neexdzii same-stack tiled vs untiled: ≥ 99.999% classified-pixel
+  agreement (12–16 px of 1.76M differ/yr), coverage within 0.002%, no seam band. The mosaic is
+  faithful — tiling is not broken.
+- **Parity — −1.88 ha (−0.20%)** tree-loss on neexdzii. Over the strict ~1 ha gate, but it is
+  1 ha-sieve quantization of a dozen edge pixels, not a modelling error. Confirms tiled ≠
+  byte-identical → fixture + published groups must stay untiled.
+- **Speedup — FAILS. Tiling is slower at every tile size, on every AOI tested.**
+  - neexdzii reach (5000 m): full step-3 **6.3× slower** (66 min vs 10.5 min).
+  - FRAN 883 km² corridor, direct fetch: 20000 m **0.79×**, 10000 m **0.31×**.
+  - Geometric + robust: a floodplain is a thin diagonal corridor — coarse tiles still blanket
+    ~92% of the bbox (no saving, N× overhead); fine tiles hug the corridor but explode
+    round-trips. No sweet spot exists.
+- **Secondary:** untiled single-year fetch is ~177 s — the "~30 min download-bound" framing is
+  dominated by classify/transition, not the fetch, so a fetch speedup would barely move step-3.
 
-_TBD._ If accuracy + parity hold: adopt `tile_size` per-area for large whole-WSG floodplains
-(set `tile_size:` in their `area.yml`), leaving the parity fixture + published groups on the
-default path. If seams degrade accuracy: keep opt-in off and record why.
+## Decision — DO NOT adopt `tile_size`
+
+The hypothesis (tile → footprint-tight download → faster) is **refuted for this geometry class**:
+the per-tile round-trip overhead exceeds the download saving because floodplain corridors tile
+badly. Accuracy is fine, so nothing is broken — it is simply not faster.
+
+- **No group sets `tile_size:`.** All areas stay on the untiled default path.
+- **Keep the opt-in wired** (default off, harmless) — it costs nothing and may suit a different
+  source/geometry later; ripping it out would just churn a merged, inert knob.
+- **The real fix for bbox-download waste is in-cube** (drift#36 `filter_geom` polygon clip),
+  blocked upstream by gdalcubes#110 — not client-side square tiling. Track there, not here.

--- a/scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_fran.md
+++ b/scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_fran.md
@@ -1,0 +1,45 @@
+# FRAN tile_size fetch-speedup benchmark (#8)
+
+**Date:** 2026-07-11 · **Stack:** drift 0.6.0, terra 1.9.34 · **AOI:** FRAN `ch_ff04`
+(883 km², bbox 11,708 km² → footprint 7.5% of bbox — a thin diagonal corridor) · **Method:**
+direct `dft_stac_fetch` timing, year 2023, cold (`force=TRUE`), isolated `cache_dir` (never
+touches the shared cache). Reuses the existing FRAN step-1/2 output — no re-model needed.
+
+## Result
+
+| fetch | tiles | real (s) | vs untiled | valid cells |
+|---|---|---|---|---|
+| untiled | — | 177.1 | 1.00× | 9,116,848 |
+| tiled 20000 m | 27 | 225.4 | **0.79×** | 9,117,073 |
+| tiled 10000 m | 84 | 564.5 | **0.31×** | 9,117,073 |
+
+Output is equivalent (0.002% valid-cell diff). Tiling is **slower at every tile size**.
+
+## Why (robust, geometric)
+
+A floodplain is a thin diagonal corridor — the worst case for square-tile coverage:
+- **Coarse tiles** (20 km, 27 of them) still blanket ~92% of the bbox (27 × 400 km² ≈ 10,800 of
+  11,708 km²) → almost no download saving, but 27× the per-tile gdalcubes cube-build + read + a
+  `terra::merge`. Net slower.
+- **Fine tiles** (10 km, 84 of them) cover less area but the round-trip overhead explodes → 3.2×
+  slower.
+- There is no sweet spot: the corridor's footprint (7.5%) can only be captured tightly by tiles
+  small relative to the corridor *width*, which forces many tiles → overhead dominates.
+
+Corroborated by neexdzii (171 km² reach, `tile_size=5000`): full step-3 was 6.3× slower
+(66 min vs 10.5 min). Both a small reach and the largest whole-WSG floodplain lose.
+
+## Secondary finding
+
+The untiled single-year fetch is only ~177 s — the "~30 min, download-bound" cost noted in
+CLAUDE.md is dominated by classify/transition over 3 years + both passes, NOT the fetch. So even
+a hypothetical fetch speedup would not move step-3 wall-clock much. The download-bound framing
+overstated the fetch's share.
+
+## Verdict
+
+**Do not adopt `tile_size` for floodplain LULC.** Accuracy is fine (see neexdzii log,
+≥99.999%) — tiling is not broken, it is just slower for this geometry class. The bbox-download
+waste must be attacked in-cube (drift#36's `filter_geom` polygon clip, blocked upstream by
+gdalcubes#110), not by client-side square tiling. Keep the opt-in wired (harmless, default off);
+set it on no group.

--- a/scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_neexdzii.md
+++ b/scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_neexdzii.md
@@ -1,0 +1,58 @@
+# neexdzii tile_size benchmark — parity + accuracy gate (#8)
+
+**Date:** 2026-07-11 · **Stack:** drift 0.6.0, terra 1.9.34, link 0.44.2, flooded 0.3.2 ·
+**AOI:** neexdzii `co_ff04` (BULK reach, ~171 km²; interior sub-basins) · **tile_size:** 5000 m
+· **Scenario:** step 3 only (existing step 1/2 outputs reused).
+
+Same-stack comparison — both runs on drift 0.6.0. Untiled reproduces the documented fixture, so
+the only variable is `tile_size`.
+
+## Timing (wall-clock, step 3 end-to-end incl. classify + both passes)
+
+| run | real (s) | real (min) |
+|---|---|---|
+| untiled | 631 | 10.5 |
+| tiled (5000 m) | 3959 | **66.0** |
+
+**Tiling is 6.3× SLOWER here.** Pass 1 fanned the reach into ~75 tiles/year (× 3 years) and
+pass 2 fetched ~8 tiles/sub-basin/year; the per-tile round-trip overhead dwarfs a single
+bbox stream. tile_size is a *large-bbox* optimization — on a compact reach it is strictly worse.
+
+## Parity (gross tree-loss / gain, ha)
+
+| metric | untiled | tiled | Δ |
+|---|---|---|---|
+| loss | 943.13 | 941.25 | **−1.88** (−0.20%) |
+| gain | 197.10 | 197.62 | +0.52 |
+
+Untiled = the documented 943.13 ha fixture exactly. The −1.88 ha is downstream sieve
+quantization: the 1 ha `patch_min_m2` bins the ~dozen differing edge pixels (below) into/out of
+~2 threshold-straddling patches. Exceeds the strict ~1 ha gate, but it is a sieve artifact, not
+a classification error.
+
+## Accuracy (classified-pixel agreement, overlapping non-NA px, ~1.76M/yr)
+
+| year | agreement | disagreeing px |
+|---|---|---|
+| 2017 | 99.9991% | 16 |
+| 2020 | 99.9992% | 14 |
+| 2023 | 99.9993% | 12 |
+
+Coverage: untiled 1,785,557 vs tiled 1,785,598 non-NA cells (2023) — 41-cell (0.002%) diff.
+12–16 scattered pixels, decreasing over years — AOI-margin / mosaic-edge, **not a systematic
+seam band**. The mosaic preserves the classification.
+
+## Verdict (neexdzii)
+
+- **Accuracy: PASS** — ≥ 99.999%, no seam band. The tiled mosaic is faithful.
+- **Parity: −1.88 ha** — over the strict ~1 ha gate but a sieve-quantization artifact of a dozen
+  edge pixels (0.2%). Confirms tiled ≠ byte-identical → fixture + published groups stay untiled.
+- **Speedup: NEGATIVE (6.3× slower)** — tile_size must NOT be applied to small reaches. The
+  benchmark that matters is a large whole-WSG corridor (PCEA), where the untiled bbox is the cost.
+
+## Implications for PCEA / adoption
+
+- Only groups where the floodplain footprint is a *small fraction of the bbox* can win. Choose a
+  **larger** tile_size for PCEA (10000–20000 m) to cap round-trips; 5000 m over-fragments.
+- Adoption tolerance: accept the ~0.2% sieve-quantized tree-loss shift IF a real speedup lands;
+  judge on the pre-sieve pixel agreement (the faithful metric), not byte-parity.


### PR DESCRIPTION
## Summary

Benchmark results + decision for the `tile_size` (drift#36) investigation. **Negative result:
do not adopt.** Tiling is accurate but slower for floodplain geometry.

- **Accuracy PASS** — neexdzii tiled vs untiled classified rasters agree >= 99.999% (12-16 px of
  1.76M/yr), coverage within 0.002%, no seam band. The mosaic is faithful.
- **Parity** — tree-loss 943.13 ha untiled (reproduces the fixture) vs 941.25 ha tiled
  (Δ -1.88 ha) — 1 ha patch-sieve quantization of a dozen edge pixels, not a modelling error.
- **Speedup FAILS** — tiling is slower at every tile size on every AOI. neexdzii full step-3 was
  6.3x slower; FRAN 883 km2 direct fetch 0.79x (20 km) / 0.31x (10 km). A floodplain is a thin
  diagonal corridor that tiles badly: coarse tiles blanket the bbox (no download saving, N x
  per-tile overhead), fine tiles explode round-trips. No sweet spot.

Decision: no group sets `tile_size:` — all stay on the untiled default. The opt-in stays wired
(default off, harmless). The bbox-download waste must be fixed in-cube (drift#36 `filter_geom`),
blocked upstream by gdalcubes#110 — not client-side square tiling.

Evidence: `scripts/floodplain_lcc/logs/20260711_lulc_tile-benchmark_{neexdzii,fran}.md`; durable
verdict in `research/20260711_lulc_tile-fetch-benchmark.md`.

## Related Issues
- Closes #8
- Relates to NewGraphEnvironment/sred#35

## Test plan
- [x] Same-stack (drift 0.6.0) tiled-vs-untiled comparison; untiled reproduces the 943.13 ha fixture
- [x] Speedup measured on the existing FRAN floodplain (no PCEA steps 1-2 needed)
- [x] Shared drift cache untouched (isolated cache / `force`, never a wipe)

## Notes
Method (opt-in `tile_size` wiring) shipped in #9; this PR is the evidence + decision that closes
the investigation. No code change — the opt-in remains available but is adopted by no group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
