### PR TITLE
fp_lulc: reuse Pass 1 classified raster in Pass 2 (12.4x faster, identical output)

### DIFF
--- a/scripts/floodplain_lcc/03_lulc_classify.R
+++ b/scripts/floodplain_lcc/03_lulc_classify.R
@@ -161,9 +161,12 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
     }
 
     message("Processing: ", lab)
-    rasters <- dft_stac_fetch(fp_clip, source = "io-lulc", years = years,
-                              tile_size = cfg$tile_size)
-    classified <- dft_rast_classify(rasters, source = "io-lulc")
+    # Reuse Pass 1's whole-floodplain classified raster instead of re-fetching per
+    # sub-basin: each sub-basin is a subset of classified_all, so crop + mask gives the
+    # same pixels with no STAC round-trip. classified_all is auto-UTM; fp_clip is in the
+    # floodplain CRS, so project it to the raster CRS before cropping. (#11)
+    v <- terra::project(terra::vect(fp_clip), terra::crs(classified_all))
+    classified <- terra::mask(terra::crop(classified_all, v), v)
     summary <- dft_rast_summarize(classified, unit = "ha")
     summary$name_basin <- lab
     results[[i]] <- summary

--- a/scripts/floodplain_lcc/logs/20260711_lulc_pass2-reuse_neexdzii.md
+++ b/scripts/floodplain_lcc/logs/20260711_lulc_pass2-reuse_neexdzii.md
@@ -1,0 +1,30 @@
+# fp_lulc Pass-2 reuse — validation + speedup (#11)
+
+**Date:** 2026-07-11 · **Stack:** drift 0.6.0, terra 1.9.34 · **AOI:** neexdzii `co_ff04`
+(14 sub-basins) · **Change:** Pass 2 crops+masks Pass 1's `classified_all` per sub-basin instead
+of re-fetching STAC. Same-stack A/B on step 3.
+
+## Speedup
+
+| run | STAC queries | real (s) |
+|---|---|---|
+| baseline (re-fetch per sub-basin) | 15 (1 Pass 1 + 14 Pass 2) | 631 |
+| reuse (crop+mask Pass 1) | **1** | **51** |
+
+**12.4× faster.** Pass 2's 14 fetches are eliminated; it is now pure in-memory crop/mask.
+
+## Correctness — EXACT
+
+Per-sub-basin `lulc_summary` (245 rows: 14 basins × classes × 3 years) vs the same-stack
+baseline:
+- total area 52,632.3 ha both; **max per-row area delta 0.000 ha**, 0 rows differ > 0.5 ha.
+- Identical, not merely within edge noise: independent per-sub-basin fetches landed on the same
+  res-aligned UTM grid as Pass 1, so cropping Pass 1's raster returns the same pixels.
+- Pass-1 tree loss unchanged at 943.13 ha (Pass 1 was not touched).
+
+## Verdict
+
+Strictly better — 12.4× faster with byte-identical output. Adopt. Impact scales with sub-basin
+count (neexdzii 15→1 fetches); whole-WSG groups (1 sub-basin) still halve their fetch (Pass 2 no
+longer re-fetches the whole floodplain). This is the real fetch-cost lever the `tile_size`
+investigation (#8) was reaching for.


### PR DESCRIPTION
## Summary

`fp_lulc` step 3 fetched STAC land-cover twice: Pass 1 over the whole floodplain, then Pass 2
**re-fetched per sub-basin** the data Pass 1 already classified. This replaces the per-sub-basin
`dft_stac_fetch` + `dft_rast_classify` with an in-memory crop + mask of `classified_all`.

- **12.4× faster** on neexdzii (14 sub-basins): step 3 631 s → 51 s; STAC queries 15 → 1.
- **Byte-identical output** — per-sub-basin `lulc_summary` matches the same-stack baseline exactly
  (245 rows, max area delta 0.000 ha); Pass-1 tree loss unchanged (943.13 ha). The independent
  fetches landed on the same res-aligned grid, so the crop returns the same pixels.
- Whole-WSG groups (1 sub-basin) still halve their fetch (Pass 2 no longer re-fetches the whole
  floodplain).

This is the real fetch-cost lever the `tile_size` investigation (#8) was reaching for — the fetch,
not storage format or tiling, was the bottleneck.

## Related Issues
- Closes #11
- Relates to NewGraphEnvironment/sred#35

## Test plan
- [x] neexdzii A/B same stack: 12.4× speedup, per-sub-basin summaries byte-identical, tree loss 943.13 ha
- [x] Script parses; CRS handled (fp_clip projected to the auto-UTM raster CRS before crop/mask)

## Notes
Evidence: `scripts/floodplain_lcc/logs/20260711_lulc_pass2-reuse_neexdzii.md`. Pass 1 is untouched,
so whole-floodplain rasters, the transition layer, and tree-loss numbers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
