### PR TITLE
Fix Pass-2 reuse crash: classified_all is a list (#11 regression)

### DIFF
--- a/scripts/floodplain_lcc/03_lulc_classify.R
+++ b/scripts/floodplain_lcc/03_lulc_classify.R
@@ -163,10 +163,12 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
     message("Processing: ", lab)
     # Reuse Pass 1's whole-floodplain classified raster instead of re-fetching per
     # sub-basin: each sub-basin is a subset of classified_all, so crop + mask gives the
-    # same pixels with no STAC round-trip. classified_all is auto-UTM; fp_clip is in the
-    # floodplain CRS, so project it to the raster CRS before cropping. (#11)
-    v <- terra::project(terra::vect(fp_clip), terra::crs(classified_all))
-    classified <- terra::mask(terra::crop(classified_all, v), v)
+    # same pixels with no STAC round-trip. classified_all is a NAMED LIST of per-year
+    # SpatRasters (indexed classified_all[[yr]] above), so crop/mask each element; the
+    # rasters are auto-UTM and fp_clip is in the floodplain CRS, so project fp_clip to
+    # the raster CRS first. dft_rast_summarize takes the same list shape as Pass 1. (#11)
+    v <- terra::project(terra::vect(fp_clip), terra::crs(classified_all[[1]]))
+    classified <- lapply(classified_all, function(r) terra::mask(terra::crop(r, v), v))
     summary <- dft_rast_summarize(classified, unit = "ha")
     summary$name_basin <- lab
     results[[i]] <- summary

--- a/scripts/floodplain_lcc/logs/20260711_lulc_pass2-reuse_neexdzii.md
+++ b/scripts/floodplain_lcc/logs/20260711_lulc_pass2-reuse_neexdzii.md
@@ -1,30 +1,45 @@
-# fp_lulc Pass-2 reuse — validation + speedup (#11)
+# fp_lulc Pass-2 reuse — validation + speedup (#11, corrected #13)
 
 **Date:** 2026-07-11 · **Stack:** drift 0.6.0, terra 1.9.34 · **AOI:** neexdzii `co_ff04`
 (14 sub-basins) · **Change:** Pass 2 crops+masks Pass 1's `classified_all` per sub-basin instead
-of re-fetching STAC. Same-stack A/B on step 3.
+of re-fetching STAC.
 
-## Speedup
+> **Correction (this file first reported a FALSE result).** The initial reuse code called
+> `terra::crs(classified_all)` — but `classified_all` is a *list*, so Pass 2 errored
+> (`crs` on `"list"`) and halted **before** writing `lulc_summary.rds`. The run still exited 0
+> (wrapper), and the A/B compare then read the *unchanged* baseline file against its own backup —
+> a trivial "identical / 12.4×" that was an artifact of the crash, not a validated result. Fixed
+> in #13 (crop/mask each list element; get CRS from `classified_all[[1]]`). Numbers below are the
+> real, post-fix run, verified by: no `Execution halted`, `lulc_summary.rds` newer than run start,
+> all 14 sub-basins processed.
+
+## Speedup (real — Pass 2 executed)
 
 | run | STAC queries | real (s) |
 |---|---|---|
 | baseline (re-fetch per sub-basin) | 15 (1 Pass 1 + 14 Pass 2) | 631 |
-| reuse (crop+mask Pass 1) | **1** | **51** |
+| reuse (crop+mask Pass 1) | **1** | **54.9** |
 
-**12.4× faster.** Pass 2's 14 fetches are eliminated; it is now pure in-memory crop/mask.
+**11.5× faster.** Pass 2's 14 fetches become in-memory crop/mask (~4 s for all 14 on top of the
+~51 s Pass 1).
 
-## Correctness — EXACT
+## Correctness — near-identical, NOT byte-identical
 
-Per-sub-basin `lulc_summary` (245 rows: 14 basins × classes × 3 years) vs the same-stack
-baseline:
-- total area 52,632.3 ha both; **max per-row area delta 0.000 ha**, 0 rows differ > 0.5 ha.
-- Identical, not merely within edge noise: independent per-sub-basin fetches landed on the same
-  res-aligned UTM grid as Pass 1, so cropping Pass 1's raster returns the same pixels.
-- Pass-1 tree loss unchanged at 943.13 ha (Pass 1 was not touched).
+Per-sub-basin `lulc_summary` (245 rows) vs the true baseline (14 independent fetches):
+- total area 52,632.3 → 52,629.7 ha (**−2.58 ha, 0.005%**); max per-row delta **2.21 ha**
+  (0.4% of a 519 ha class·basin·year); 46/245 rows differ > 0.5 ha.
+- Cause: the reuse assigns every sub-basin from the **single floodplain grid**; independent
+  fetches each land on their **own auto-UTM grid**, so boundary pixels shift. The reuse is
+  arguably *more* consistent — sub-basins cleanly partition one grid rather than re-gridding, so
+  they sum to the whole-floodplain total without boundary double-count/gap.
+- Whole-floodplain **tree loss unchanged at 943.13 ha** (Pass 1 untouched).
 
 ## Verdict
 
-Strictly better — 12.4× faster with byte-identical output. Adopt. Impact scales with sub-basin
-count (neexdzii 15→1 fetches); whole-WSG groups (1 sub-basin) still halve their fetch (Pass 2 no
-longer re-fetches the whole floodplain). This is the real fetch-cost lever the `tile_size`
-investigation (#8) was reaching for.
+Adopt: 11.5× faster, sub-basin summaries within 0.005% (VCA-noise band) and arguably more
+internally consistent, whole-floodplain numbers unchanged. Impact scales with sub-basin count
+(neexdzii 15→1 fetches); whole-WSG groups (1 sub-basin) halve their fetch.
+
+**Process lesson:** a wrapper exit 0 is NOT "the work finished." Gate on `Execution halted` +
+the output file's mtime before trusting any A/B — the crash-before-write masqueraded as a perfect
+result.


### PR DESCRIPTION
## Summary

Fixes a regression I introduced in #11/#12: the Pass-2 reuse called `terra::crs(classified_all)`,
but `classified_all` is a **named list** of per-year SpatRasters, so `crs()` could not dispatch
and Pass 2 **halted for every group** before writing `lulc_summary.rds`. The run still exited 0
(wrapper), so the neexdzii A/B compare unknowingly read the unchanged baseline against its own
backup — a false "identical / 12.4×". Merged to main in #12, so **every step-3 run has been
crashing at Pass 2 since**.

- **Fix:** crop/mask each list element; take the CRS from `classified_all[[1]]`.
- **Properly validated** on neexdzii (no `Execution halted`; `lulc_summary.rds` rewritten; all 14
  sub-basins processed): step 3 **631 s → 54.9 s (11.5×)**.
- Per-sub-basin summaries within **0.005%** of the true baseline (edge-pixel effects — one
  floodplain grid vs per-sub-basin grids; arguably more consistent). Whole-floodplain tree loss
  unchanged (943.13 ha).

## Related Issues
- Relates to #11
- Relates to NewGraphEnvironment/sred#35

## Test plan
- [x] neexdzii step 3: exit 0, no `Execution halted`, `lulc_summary.rds` freshly written, 14/14 sub-basins
- [x] 11.5× speedup; summaries within 0.005% of the true baseline; tree loss 943.13 ha

## Notes
Process lesson (in the log): a wrapper exit 0 is not "the work finished" — gate on `Execution
halted` + output-file mtime before trusting any A/B comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
