### PR TITLE
fp_network: build-or-grab network source, freshness guard + lnk_stamp provenance (closes #14)

### DIFF
--- a/scripts/floodplain_lcc/01_network_extract.R
+++ b/scripts/floodplain_lcc/01_network_extract.R
@@ -9,7 +9,9 @@
 #   waterbodies_co3  lakes/wetlands on the accessible network
 #
 # `link` is watershed-group scoped, so we run cfg$watershed_group, persist into the
-# DEDICATED cfg$schema (never the shared province-wide `fresh.*`). If cfg$subset is set
+# DEDICATED cfg$schema. When cfg$network_source is set (e.g. "fresh_default") the accessible
+# network is GRABBED from that already-built schema instead of re-running the pipeline, with
+# a freshness guard against the bcfp reference (#14). If cfg$subset is set
 # (blue_line_key + downstream_route_measure) the network is subset to that reach
 # (e.g. Neexdzii = upstream of the Wedzin Kwa confluence within BULK); if cfg$subset is
 # NULL the whole watershed group is exported (e.g. MORR).
@@ -48,6 +50,17 @@ fp_network <- function(cfg) {
          species, call. = FALSE)
   }
 
+  # Network source: BUILD (default) re-runs the link pipeline into cfg$schema; GRAB reads
+  # the accessible network from an already-built schema (cfg$network_source, e.g.
+  # "fresh_default"), skipping the pipeline. Grab schemas are province-wide, so the read
+  # below filters watershed_group_code and a freshness guard checks the grabbed km against
+  # the bcfp reference (a stale source fails loud). (#14)
+  grab        <- !is.null(cfg$network_source) && nzchar(cfg$network_source)
+  read_schema <- if (grab) cfg$network_source else schema
+
+  if (grab) {
+    message("Network source: GRAB from '", read_schema, "' (skipping link pipeline build).")
+  } else {
   # --- Run the link habitat pipeline for the watershed group ---
   # Use the `default` config (NewGraph methodology), NOT `bcfishpass`. They differ
   # in the natural-barrier set: bcfishpass opts in `subsurfaceflow` for parity,
@@ -82,6 +95,7 @@ fp_network <- function(cfg) {
                    dams = TRUE, mapping_code = FALSE)
 
   message("Pipeline complete (schema ", schema, ").")
+  }
 
   # --- Read the species-accessible network ---
   # access_<species> IN (1,2): 1 = modelled accessible past natural barriers,
@@ -105,9 +119,37 @@ fp_network <- function(cfg) {
     ) ua ON ua.linear_feature_id = s.linear_feature_id
     LEFT JOIN whse_basemapping.fwa_stream_networks_mean_annual_precip p
       ON p.wscode_ltree = s.wscode_ltree AND p.localcode_ltree = s.localcode_ltree
-    WHERE a.access_%3$s IN (1, 2) AND s.stream_order >= %2$s",
-    schema, min_order, species)
+    WHERE a.access_%3$s IN (1, 2) AND s.stream_order >= %2$s
+      AND s.watershed_group_code = '%4$s'",
+    read_schema, min_order, species, aoi_wsg)
   streams <- sf::st_read(conn, query = streams_sql, quiet = TRUE) |> sf::st_zm(drop = TRUE)
+
+  # --- Freshness guard (grab only) ---
+  # A shared schema is not uniformly current per-WSG, so compare the grabbed accessible km
+  # to the province bcfp reference and fail loud if it diverges beyond tolerance (default
+  # 2%). A current default-config source is within ~0.5% of bcfp; a stale one is caught
+  # here instead of silently shifting the floodplain. Checked on the full-WSG read, before
+  # any reach subset. (#14)
+  if (grab) {
+    grab_km <- sum(streams$length_metre, na.rm = TRUE) / 1000
+    bcfp_km <- DBI::dbGetQuery(conn, sprintf(
+      "SELECT sum(length_metre)/1000.0 FROM fresh.streams_vw_bcfp
+       WHERE access_%1$s IN (1,2) AND stream_order >= %2$d AND watershed_group_code = '%3$s'",
+      species, min_order, aoi_wsg))[1, 1]
+    tol <- if (is.null(cfg$network_source_tol)) 0.02 else cfg$network_source_tol
+    if (is.na(bcfp_km) || bcfp_km == 0) {
+      message("Freshness check: no bcfp reference for ", aoi_wsg, "/", species,
+              " — cannot verify '", read_schema, "'; proceeding.")
+    } else {
+      dev <- abs(grab_km - bcfp_km) / bcfp_km
+      message(sprintf("Freshness check: grabbed %.0f km vs bcfp reference %.0f km (%.1f%% dev, tol %.0f%%).",
+                      grab_km, bcfp_km, 100 * dev, 100 * tol))
+      if (dev > tol) {
+        stop(sprintf("network_source '%s' diverges from bcfp by %.1f%% (> %.0f%% tol) for %s -- likely stale; rebuild (drop network_source) or refresh the source.",
+                     read_schema, 100 * dev, 100 * tol, aoi_wsg), call. = FALSE)
+      }
+    }
+  }
 
   # --- Optional reach subset ---
   # If cfg$subset is set, keep only the network upstream of the confluence measure

--- a/scripts/floodplain_lcc/01_network_extract.R
+++ b/scripts/floodplain_lcc/01_network_extract.R
@@ -57,6 +57,12 @@ fp_network <- function(cfg) {
   # the bcfp reference (a stale source fails loud). (#14)
   grab        <- !is.null(cfg$network_source) && nzchar(cfg$network_source)
   read_schema <- if (grab) cfg$network_source else schema
+  net_source  <- if (grab) paste0("GRAB from ", read_schema) else paste0("BUILD into ", schema)
+  fresh_note  <- "built (no freshness check)"
+  # network_guard: strict (default, stop on divergence) | warn (log + proceed) | off (skip
+  # the check). Set warn/off when a divergence is EXPECTED and understood -- updated crossings
+  # data or a deliberately different config -- with the stamp sidecar recording the override.
+  guard       <- if (is.null(cfg$network_guard)) "strict" else cfg$network_guard
 
   if (grab) {
     message("Network source: GRAB from '", read_schema, "' (skipping link pipeline build).")
@@ -138,15 +144,24 @@ fp_network <- function(cfg) {
       species, min_order, aoi_wsg))[1, 1]
     tol <- if (is.null(cfg$network_source_tol)) 0.02 else cfg$network_source_tol
     if (is.na(bcfp_km) || bcfp_km == 0) {
-      message("Freshness check: no bcfp reference for ", aoi_wsg, "/", species,
-              " — cannot verify '", read_schema, "'; proceeding.")
+      fresh_note <- sprintf("grabbed %.0f km; no bcfp reference (UNVERIFIED)", grab_km)
+      message("Freshness check: ", fresh_note)
     } else {
       dev <- abs(grab_km - bcfp_km) / bcfp_km
-      message(sprintf("Freshness check: grabbed %.0f km vs bcfp reference %.0f km (%.1f%% dev, tol %.0f%%).",
-                      grab_km, bcfp_km, 100 * dev, 100 * tol))
+      fresh_note <- sprintf("grabbed %.0f km vs bcfp %.0f km = %.1f%% dev (tol %.0f%%, guard=%s)",
+                            grab_km, bcfp_km, 100 * dev, 100 * tol, guard)
+      message("Freshness check: ", fresh_note)
       if (dev > tol) {
-        stop(sprintf("network_source '%s' diverges from bcfp by %.1f%% (> %.0f%% tol) for %s -- likely stale; rebuild (drop network_source) or refresh the source.",
-                     read_schema, 100 * dev, 100 * tol, aoi_wsg), call. = FALSE)
+        msg <- sprintf("network_source '%s' diverges from bcfp by %.1f%% (> %.0f%% tol) for %s",
+                       read_schema, 100 * dev, 100 * tol, aoi_wsg)
+        if (identical(guard, "off")) {
+          message(msg, " -- network_guard=off, proceeding (override recorded in stamp).")
+        } else if (identical(guard, "warn")) {
+          warning(msg, " -- network_guard=warn, proceeding.", call. = FALSE)
+        } else {
+          stop(msg, " -- likely stale. If intentional (updated crossings / different config), ",
+               "set network_guard: warn|off; else drop network_source to build.", call. = FALSE)
+        }
       }
     }
   }
@@ -193,6 +208,21 @@ fp_network <- function(cfg) {
                  append = TRUE, quiet = TRUE)
   }
   message("Saved: ", basename(out_gpkg))
+
+  # --- Provenance stamp sidecar ---
+  # lnk_stamp records config identity + link/fresh versions + git SHAs + a DB snapshot
+  # (bcfishobs.observations = the crossings/observations signal) + per-file config
+  # provenance (the crossings/barrier override CSVs + their drift status). Written next to
+  # every network so a floodplain self-documents what produced it -- and so a grab-guard
+  # override (network_guard = warn|off) is auditable: the stamp shows whether the source's
+  # divergence lines up with updated crossings / a different config. (#14)
+  stamp <- lnk_stamp_finish(lnk_stamp(lnk_config("default"), conn, aoi = aoi_wsg))
+  stamp_md <- c(format(stamp, "markdown"), "",
+                "### Floodplains network source",
+                paste0("- source: ", net_source),
+                paste0("- freshness: ", fresh_note))
+  writeLines(stamp_md, file.path(out_dir, "aquatic_network.stamp.md"))
+  message("Wrote provenance sidecar: aquatic_network.stamp.md")
 
   invisible(out_gpkg)
 }

--- a/scripts/floodplain_lcc/logs/20260711_network-source-grab_peace.md
+++ b/scripts/floodplain_lcc/logs/20260711_network-source-grab_peace.md
@@ -33,6 +33,32 @@ Verified by exit code + the freshness message + built-vs-grab km/segments + that
 did not overwrite `data/pcea/aquatic_network.gpkg`. PARS's built network was restored after the
 grab test (functionally identical; keeps it matched to its already-built floodplain).
 
+## Provenance stamp + guard override (lnk_stamp)
+
+Step 1 now writes an `aquatic_network.stamp.md` sidecar (via `link::lnk_stamp`) next to every
+network — build or grab. It records config identity (`default`), link/fresh versions + git SHAs,
+a DB snapshot (`bcfishobs.observations` = the crossings/observations signal), per-file config
+provenance (the crossings/barrier override CSVs + byte/shape drift), AOI, and a
+"Floodplains network source" footer (source + freshness result). So a floodplain self-documents
+what produced it, and any guard override is auditable.
+
+`network_guard` (area.yml / `FP_NETWORK_GUARD`): **strict** (default, stop on divergence) |
+**warn** (log + proceed) | **off** (proceed, override recorded in stamp). Set warn/off when a
+divergence is expected and understood — updated crossings data (override CSV byte-drift) or a
+deliberately different config.
+
+Validated (`FP_NETWORK_SOURCE=fresh_default`, step 1):
+
+| run | exit | outcome |
+|---|---|---|
+| PARS, strict | 0 | 0.2% dev → pass, stamp written |
+| PCEA, strict | 1 | 4.0% dev → stop ("set network_guard: warn/off if intentional") |
+| PCEA, **guard=off** | 0 | 4.0% dev → proceeds; stamp records `source: GRAB from fresh_default`, `freshness: 4.0% dev, guard=off`, config provenance (0 drift) + observations 372,690 |
+
+`fresh_default` carries no in-DB stamp, so the stamp is generated at build/grab time (captures the
+current config/version/DB state). Built networks were restored + grab-test sidecars removed after
+the check (`data/` is gitignored).
+
 ## Scope
 
 Validated at **step 1** (network read + guard). Steps 2–3 consume `aquatic_network.gpkg` agnostic

--- a/scripts/floodplain_lcc/logs/20260711_network-source-grab_peace.md
+++ b/scripts/floodplain_lcc/logs/20260711_network-source-grab_peace.md
@@ -1,0 +1,41 @@
+# fp_network grab-from-schema + freshness guard — validation (#14)
+
+**Date:** 2026-07-11 · **Stack:** link 0.44.2, drift 0.6.0 · **Change:** step 1 can GRAB the
+accessible network from an existing schema (`cfg$network_source`, e.g. `fresh_default`) instead of
+re-running `lnk_pipeline_run`, guarded by a bcfp-reference freshness check.
+
+## Why
+
+Step 1 re-ran the whole link pipeline every time. When a compatible default-config network is
+already materialized (`fresh_default`), that is the same "recompute what's already there"
+redundancy removed in Pass 2 (#11). But a shared schema is **not uniformly current per-WSG**, so a
+blind grab is unsafe — hence the guard.
+
+## Freshness anchor
+
+A current default-config network sits within ~0.5% of the province bcfp reference
+(`fresh.streams_vw_bcfp`); a stale one diverges. So the guard needs no expensive rebuild — compare
+grabbed accessible-km to bcfp, `stop()` beyond tol (default 2%).
+
+| WSG | bcfp ref | fresh build (0.44.2) | fresh_default |
+|---|---|---|---|
+| PCEA | 2,194 km | 2,200 (0.3%) | 2,281 (**4.0%**) |
+| PARS | 2,310 km | 2,314 (0.2%) | 2,314 (0.2%) |
+
+## Validation (`FP_NETWORK_SOURCE=fresh_default`, step 1)
+
+| WSG | freshness check | exit | outcome |
+|---|---|---|---|
+| **PARS** | grabbed 2,314 vs bcfp 2,310 = 0.2% ≤ 2% | 0 | GRAB ok — 9,387 seg / 2,314 km, matches the built 9,386 / 2,314 (skips the link pipeline) |
+| **PCEA** | grabbed 2,281 vs bcfp 2,194 = 4.0% > 2% | 1 | **refused** ("diverges from bcfp by 4.0% — likely stale"); `data/pcea` left untouched |
+
+Verified by exit code + the freshness message + built-vs-grab km/segments + that the refused grab
+did not overwrite `data/pcea/aquatic_network.gpkg`. PARS's built network was restored after the
+grab test (functionally identical; keeps it matched to its already-built floodplain).
+
+## Scope
+
+Validated at **step 1** (network read + guard). Steps 2–3 consume `aquatic_network.gpkg` agnostic
+to how it was produced, so the grab network flows through unchanged. Grab is for default-config
+(bt/grayling) sources; chinook/other configs need their own current source. Absent
+`network_source` => BUILD (default) — unchanged for every existing area.

--- a/scripts/run_area.R
+++ b/scripts/run_area.R
@@ -53,6 +53,12 @@ fp_read_config <- function(area) {
   # unsetting the var, never risking a committed tile_size in the fixture. Empty => no override.
   env_tile <- Sys.getenv("FP_TILE_SIZE", "")
   if (nzchar(env_tile)) cfg$tile_size <- as.numeric(env_tile)
+  # network_source (optional area.yml key): a schema to GRAB the accessible network from in
+  # step 1 (e.g. "fresh_default"), skipping the link build; absent => build. A freshness guard
+  # (fp_network) refuses a source that diverges from the bcfp reference. FP_NETWORK_SOURCE
+  # overrides at runtime without editing a committed config (used to validate a source).
+  env_ns <- Sys.getenv("FP_NETWORK_SOURCE", "")
+  if (nzchar(env_ns)) cfg$network_source <- env_ns
   cfg
 }
 

--- a/scripts/run_area.R
+++ b/scripts/run_area.R
@@ -59,6 +59,11 @@ fp_read_config <- function(area) {
   # overrides at runtime without editing a committed config (used to validate a source).
   env_ns <- Sys.getenv("FP_NETWORK_SOURCE", "")
   if (nzchar(env_ns)) cfg$network_source <- env_ns
+  # network_guard (optional): strict (default) | warn | off — override the grab freshness
+  # guard when a divergence is expected (updated crossings / different config). The
+  # lnk_stamp sidecar records the override. FP_NETWORK_GUARD overrides at runtime.
+  env_guard <- Sys.getenv("FP_NETWORK_GUARD", "")
+  if (nzchar(env_guard)) cfg$network_guard <- env_guard
   cfg
 }
 


### PR DESCRIPTION
## Summary

Makes step 1's network **source** config-driven with a provenance stamp and an overridable
freshness guard — so we can build from scratch OR grab from any already-built schema, know exactly
what produced each floodplain, and knowingly override the guard when a divergence is expected.

- **`cfg$network_source`** (area.yml / `FP_NETWORK_SOURCE`): a schema to GRAB the accessible
  network from (e.g. `fresh_default`), skipping the whole link pipeline. Absent => BUILD
  (unchanged for every existing area). Grab read gains a `watershed_group_code` filter (grab
  schemas are province-wide — else the read is cartesian).
- **Freshness guard** compares grabbed accessible-km to the province bcfp reference
  (`fresh.streams_vw_bcfp`); a current default-config source is within ~0.5%, a stale one diverges.
- **`network_guard`** (area.yml / `FP_NETWORK_GUARD`): strict (default, stop) | warn (log +
  proceed) | off (proceed). Override when the divergence is expected — updated crossings data or a
  deliberately different config.
- **`lnk_stamp` sidecar** (`aquatic_network.stamp.md`) next to every network: config identity,
  link/fresh versions + SHAs, DB snapshot (`bcfishobs.observations`), per-file config provenance
  (crossings/barrier override CSVs + drift), source + freshness footer. Self-documents what
  produced each floodplain and makes any guard override auditable.

## Validation (`FP_NETWORK_SOURCE=fresh_default`, step 1)

| run | exit | outcome |
|---|---|---|
| PARS, strict | 0 | 0.2% dev → grab reproduces the built 2,314 km network, skips the pipeline, stamp written |
| PCEA, strict | 1 | 4.0% dev → refused ("set network_guard: warn/off if intentional") |
| PCEA, guard=off | 0 | 4.0% dev → proceeds; stamp records the override + config/crossings state |

Verified by exit codes, freshness messages, built-vs-grab km/segments, and that refused/overridden
grabs did not silently corrupt data (built networks restored, test sidecars removed).

## Related Issues
- Closes #14
- Relates to NewGraphEnvironment/sred#35

## Test plan
- [x] PARS grab passes + reproduces built network; PCEA strict refused; PCEA guard=off proceeds + logged
- [x] Stamp sidecar written (build + grab) with config/version/DB/crossings provenance
- [x] Scripts parse; BUILD path unchanged for areas without `network_source`

## Notes
Validated at step 1; steps 2–3 consume `aquatic_network.gpkg` agnostic to how it was produced.
Grab is for default-config (bt/grayling) sources. Evidence:
`scripts/floodplain_lcc/logs/20260711_network-source-grab_peace.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
