### PR TITLE
Add PINE (Peace, bull trout) area

### DIFF
--- a/config/pine/area.yml
+++ b/config/pine/area.yml
@@ -1,0 +1,6 @@
+name: pine
+watershed_group: PINE
+species: bt
+min_order: 3
+schema: pine
+primary_scenario: bt_ff04

--- a/config/pine/flood_scenarios.csv
+++ b/config/pine/flood_scenarios.csv
@@ -1,0 +1,7 @@
+scenario_id,species,min_order,anchor_order,flood_factor,slope_threshold,max_width,cost_threshold,size_threshold,hole_threshold,lakes,wetlands,wetland_filter,run,description,ecological_process,citations
+bt_ff01,bt,3,1,1,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Bankfull channel extent,Active channel,
+bt_ff02,bt,3,1,2,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Flood-prone width / active channel margin,Active channel margin,
+bt_ff04,bt,3,1,4,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Functional floodplain,Functional floodplain,
+bt_ff06,bt,3,1,6,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Valley bottom extent,Valley bottom,
+bt_ff08,bt,3,1,8,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Extended valley - large wood recruitment,Extended valley / LWD recruitment,
+bt_ff12,bt,3,1,12,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Channel migration zone - full process width,Channel migration zone,

--- a/config/regions/peace.yml
+++ b/config/regions/peace.yml
@@ -3,12 +3,13 @@
 # and `bt` carries the network. Same whole-WSG treatment as the Fraser groups (no
 # break_points.csv => the FWA group polygon is the single sub-basin).
 #
-# PINE (Pine River) belongs to this region but is NOT yet loaded in the local fwapg build
-# (0 segments in fresh.streams_vw_bcfp) — add it here after a link/bcfishpass build loads it.
-# The pre-pass will loudly SKIP any listed group with no modelled network, so PINE can be
-# added now and will simply be reported as SKIPPED until the data exists.
+# PINE (Pine River) was loaded via a link build: fresh_default + the fwapg base carry it
+# (8,509 bt segments / 2,152 km at order >= 3). NOTE: it is NOT in fresh.streams_vw_bcfp (the
+# bcfishpass reference view was not refreshed), so the run_region PRE-PASS — which checks that
+# view — will still SKIP PINE. Run it directly (`run_area.R pine`, BUILD reads the fwapg base)
+# until the bcfp view is refreshed, or the pre-pass is pointed at fresh_default.
 region: peace
 mergin_project: TBD              # doc-only; set when a Peace field project exists
 min_order: 3
 species: [bt]                    # bull trout only (ch unmodelled on the Arctic slope)
-watershed_groups: [PCEA, PARS]   # PINE pending a link build
+watershed_groups: [PCEA, PARS, PINE]   # PINE built; see pre-pass caveat above


### PR DESCRIPTION
## Summary

PINE (Pine River, Peace drainage) was loaded via a link build, so add it as a runnable area.

- `config/pine/` — bull trout, whole-WSG, `bt_ff04` (matches PCEA/PARS).
- `peace.yml` lists PINE, with a caveat: PINE is in `fresh_default` + the fwapg base (8,509 bt
  segments / 2,152 km at order >= 3) but **not** in `fresh.streams_vw_bcfp`, so the `run_region`
  pre-pass still skips it — run directly via `run_area.R pine` (BUILD reads the fwapg base) until
  the bcfp view is refreshed.

Run (build, steps 1-3): floodplain `bt_ff04` **379.7 km²**, tree loss 763.1 ha / gain 1,497.0 ha /
**net +733.9 ha**, coverage 1.05. Provenance stamp sidecar written.

## Related Issues
- Relates to #3
- Relates to NewGraphEnvironment/sred#35

## Test plan
- [x] PINE runs clean end-to-end (build path); coverage check 1.05
- [x] Config matches the bt whole-WSG template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
