### PR TITLE
Add BOWR, MCGR to fraser.yml watershed_groups (#17)

### DIFF
--- a/config/regions/fraser.yml
+++ b/config/regions/fraser.yml
@@ -1,4 +1,4 @@
-# Fraser region — the 8 watershed groups in the sern_fraser_2024 project.
+# Fraser region — the watershed groups in the sern_fraser_2024 project.
 # The runner resolves ONE species per WSG: the first in `species` (ordered preference)
 # that is modelled at order >= min_order (checked against the province-wide
 # fresh.streams_vw_bcfp). A WSG where NONE of the listed species is modelled is NOT run
@@ -7,4 +7,4 @@ region: fraser
 mergin_project: newgraph/sern_fraser_2024
 min_order: 3
 species: [ch, bt]          # ordered: chinook, then bull trout
-watershed_groups: [LCHL, LSAL, WILL, TABR, UFRA, NECR, MORK, FRAN]
+watershed_groups: [LCHL, LSAL, WILL, TABR, UFRA, NECR, MORK, FRAN, BOWR, MCGR]


### PR DESCRIPTION
Closes #17.

Adds `BOWR` and `MCGR` to `config/regions/fraser.yml`'s `watershed_groups`. Both are already built (chinook, `ch_ff04`, whole-WSG, order ≥ 3) with complete `ff04` outputs — they were simply missing from the Fraser roster. Since `area.yml` carries no `region` field, the roster is the only group→region link, so this formalizes existing membership with **no modelling change** (validated: `fraser.yml` parses, 10 groups).

Unblocks `stac_floodplains_bc#3` (register the 5 new STAC groups: these two + the three Peace bull-trout groups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiSfXF2SP13JfD6V92pBws
