### PR TITLE
Add whole-WSG BULK area + fire_tag disturbance-attribution prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # Mergin CLI stray logs / cache (never commit)
 .mergin/
+
+# Bulk per-run pipeline logs (kills/retries/iteration output). Curated evidence logs
+# (yyyymmdd_noun_verb-detail_target.ext) live directly under logs/, not runs/.
+scripts/floodplain_lcc/logs/runs/

--- a/config/bulk/area.yml
+++ b/config/bulk/area.yml
@@ -1,0 +1,15 @@
+# Bulkley watershed group (BULK) — WHOLE WSG, coho.
+# `neexdzii` models only the upper reach (upstream of the Wedzin Kwa confluence); this config
+# runs the ENTIRE Bulkley group as a single sub-basin (FWA group polygon, no break_points.csv),
+# consistent with the whole-WSG treatment of MORR/UFRA/PCEA/etc. Deliberately duplicates
+# neexdzii's floodplain (neexdzii is a geographic subset of BULK) to keep storage partitioned
+# by watershed group.
+name: bulk
+watershed_group: BULK          # link aoi — whole group
+species: co                    # coho runs the whole Bulkley
+min_order: 3
+schema: bulk                   # dedicated persist schema (never shared fresh.*, never neexdzii)
+primary_scenario: co_ff04      # headline scenario for LULC (03)
+subset: null                   # whole WSG — the group polygon is the single sub-basin
+# flood_scenarios.csv copied from the coho scenario set (co_ff04 = functional floodplain).
+# No break_points.csv — whole-WSG single sub-basin.

--- a/config/bulk/flood_scenarios.csv
+++ b/config/bulk/flood_scenarios.csv
@@ -1,0 +1,7 @@
+scenario_id,species,min_order,anchor_order,flood_factor,slope_threshold,max_width,cost_threshold,size_threshold,hole_threshold,lakes,wetlands,wetland_filter,run,description,ecological_process,citations
+co_ff01,co,3,1,1,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Bankfull channel extent,Active channel,hall_etal2007Predictingriver;nagel_etal2014LandscapeScale
+co_ff02,co,3,1,2,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Flood-prone width / active channel margin,Active channel margin,hall_etal2007Predictingriver;bair_etal2021newdatadriven;nagel_etal2014LandscapeScale
+co_ff04,co,3,1,4,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Functional floodplain,Functional floodplain,hall_etal2007Predictingriver;nagel_etal2014LandscapeScale;opperman_etal2010EcologicallyFunctional;rosenfeld_etal2008EffectsSide;morley_etal2005Juvenilesalmonid
+co_ff06,co,3,1,6,9,2000,2500,5000,2500,TRUE,TRUE,network,TRUE,Valley bottom extent,Valley bottom,nagel_etal2014LandscapeScale;opperman_etal2010EcologicallyFunctional;beechie_etal2010ProcessbasedPrinciples;cluer_thorne2014StreamEvolution;hauer_etal2016Gravelbedriver
+co_ff08,co,3,1,8,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Extended valley - large wood recruitment,Extended valley / LWD recruitment,opperman_etal2010EcologicallyFunctional;wheaton_etal2019LowTechProcessBased
+co_ff12,co,3,1,12,9,2000,2500,5000,2500,TRUE,TRUE,network,FALSE,Channel migration zone - full process width,Channel migration zone,rapp_abbe2003FrameworkDelineating;obrien_etal2019Mappingvalley;wheaton_etal2019LowTechProcessBased

--- a/config/regions/skeena.yml
+++ b/config/regions/skeena.yml
@@ -1,0 +1,14 @@
+# Skeena region — upper Skeena drainage. Coho is the target species: chinook do not carry
+# these upper-Skeena networks, so `co` runs the whole watershed group. Same whole-WSG
+# treatment as the Fraser/Peace groups (no break_points.csv => the FWA group polygon is the
+# single sub-basin).
+#
+# BULK (Bulkley) runs the ENTIRE Bulkley group as a single sub-basin. NEEXDZII (Upper Bulkley)
+# is a geographic SUBSET of BULK and is deliberately NOT rostered here — publishing both would
+# produce two overlapping items over the same ground. Add it only if a distinct subset item is
+# wanted.
+region: skeena
+mergin_project: TBD              # doc-only; set when a Skeena field project exists
+min_order: 3
+species: [co]                    # coho only on these upper-Skeena groups
+watershed_groups: [BULK, MORR]   # whole-WSG coho; NEEXDZII (subset of BULK) intentionally excluded

--- a/scripts/floodplain_lcc/fire_tag.R
+++ b/scripts/floodplain_lcc/fire_tag.R
@@ -1,0 +1,85 @@
+# fire_tag.R — ONE-OFF (prototype for floodplains#19 disturbance attribution).
+# Tag each floodplain LULC transition patch with whether it falls inside a 2017-2023 fire
+# perimeter, and stamp the dominant overlapping fire's year + number. Writes a new
+# `transition_<scenario>_2017_2023_fire` layer alongside the original (original untouched).
+#
+# WHY 2017-2023: LULC change is measured 2017->2023 (io-lulc-annual-v02 ends at 2023), so only a
+# fire inside that window can EXPLAIN an observed Trees->non-Trees loss. Later perimeters are noise.
+#
+# usage: Rscript scripts/floodplain_lcc/fire_tag.R <area> [scenario]
+#   <area>     e.g. bulk         (reads data/<area>/floodplain_landcover.gpkg)
+#   [scenario] e.g. co_ff04      (default: first transition_* layer found)
+
+suppressMessages({library(sf); library(DBI); library(RPostgres); library(dplyr)})
+sf::sf_use_s2(FALSE)
+
+a    <- commandArgs(TRUE)
+area <- a[1]
+if (is.na(area)) stop("usage: Rscript fire_tag.R <area> [scenario]")
+
+gpkg <- sprintf("data/%s/floodplain_landcover.gpkg", area)
+if (!file.exists(gpkg)) stop("no gpkg: ", gpkg)
+
+lyrs <- sf::st_layers(gpkg)$name
+tlyr <- if (!is.na(a[2])) {
+  grep(sprintf("^transition_%s_", a[2]), lyrs, value = TRUE)[1]
+} else {
+  grep("^transition_", lyrs, value = TRUE)[1]
+}
+if (is.na(tlyr)) stop("no transition_ layer in ", gpkg)
+cat(sprintf("area=%s  layer=%s\n", area, tlyr))
+
+tr    <- sf::st_read(gpkg, layer = tlyr, quiet = TRUE) |> sf::st_make_valid()
+crs_t <- sf::st_crs(tr)
+
+# --- fire perimeters that could explain a 2017->2023 change ---------------------------------
+conn <- dbConnect(Postgres())
+on.exit(dbDisconnect(conn), add = TRUE)
+fire <- sf::st_read(conn, query = "
+  SELECT fire_year, fire_number, geom
+  FROM whse_land_and_natural_resource.prot_historical_fire_polys_sp
+  WHERE fire_year BETWEEN 2017 AND 2023", quiet = TRUE) |>
+  sf::st_transform(crs_t) |> sf::st_make_valid()
+cat(sprintf("fire perimeters (2017-2023, province): %d\n", nrow(fire)))
+
+# --- boolean in_fire for every patch --------------------------------------------------------
+hit <- sf::st_intersects(tr, fire)
+tr$in_fire <- lengths(hit) > 0
+
+# --- dominant overlapping fire (largest intersection area) -> year + number -----------------
+tr$fire_year   <- NA_integer_
+tr$fire_number <- NA_character_
+burn_idx <- which(tr$in_fire)
+if (length(burn_idx)) {
+  inter <- suppressWarnings(sf::st_intersection(tr[burn_idx, c("patch_id")], fire))
+  if (nrow(inter)) {
+    inter$ov <- as.numeric(sf::st_area(inter))
+    dom <- sf::st_drop_geometry(inter) |>
+      dplyr::group_by(patch_id) |>
+      dplyr::slice_max(ov, n = 1, with_ties = FALSE) |>
+      dplyr::ungroup()
+    m <- match(tr$patch_id, dom$patch_id)
+    tr$fire_year[!is.na(m)]   <- dom$fire_year[m[!is.na(m)]]
+    tr$fire_number[!is.na(m)] <- dom$fire_number[m[!is.na(m)]]
+  }
+}
+
+# --- write tagged layer alongside original --------------------------------------------------
+out_lyr <- paste0(tlyr, "_fire")
+sf::st_write(tr, gpkg, layer = out_lyr, delete_layer = TRUE, quiet = TRUE)
+cat(sprintf("wrote layer: %s (%d patches)\n", out_lyr, nrow(tr)))
+
+# --- report: tree LOSS split by fire --------------------------------------------------------
+loss <- tr[tr$from_class == "Trees" & tr$to_class != "Trees", ]
+loss_total <- sum(loss$area_ha)
+loss_fire  <- sum(loss$area_ha[loss$in_fire])
+cat(sprintf("\n=== %s Trees->non-Trees LOSS vs fire (2017-2023) ===\n", toupper(area)))
+cat(sprintf(" total loss            : %.1f ha\n", loss_total))
+cat(sprintf(" inside a fire         : %.1f ha (%.0f%%)\n", loss_fire, 100*loss_fire/loss_total))
+cat(sprintf(" outside (harvest/noise): %.1f ha (%.0f%%)\n",
+            loss_total-loss_fire, 100*(loss_total-loss_fire)/loss_total))
+brk <- sf::st_drop_geometry(loss) |>
+  dplyr::group_by(to_class, in_fire) |>
+  dplyr::summarise(ha = round(sum(area_ha),1), n = dplyr::n(), .groups="drop") |>
+  dplyr::arrange(desc(ha))
+cat("\n by to_class (patch-level fire overlap):\n"); print(as.data.frame(brk), row.names=FALSE)


### PR DESCRIPTION
## Summary
- Add `config/bulk/` — whole Bulkley watershed group (coho, dedicated `bulk` schema, no break_points => FWA group polygon is the single sub-basin), consistent with the whole-WSG treatment of MORR/UFRA/PCEA/etc. `neexdzii` models only the upper reach upstream of the Wedzin Kwa confluence; this runs the entire group. Result (co_ff04): floodplain 490.5 km², Trees→non-Trees loss 2,073.3 ha.
- Add `scripts/floodplain_lcc/fire_tag.R` — one-off disturbance-attribution prototype: tags each transition patch with `in_fire` / `fire_year` / `fire_number` by the dominant overlapping 2017–2023 fire perimeter, writes a `transition_*_fire` layer, and reports the tree-loss-vs-fire split. BULK: 5% of loss (103 ha) inside a burn perimeter, 95% land-use conversion + classification noise — not a fire-driven group. De-risks the join, the 2017–2023 window, and the dominant-fire logic ahead of generalizing them into a config-driven `fp_lulc` step.
- Add `config/regions/skeena.yml` — Skeena region roster (whole-WSG coho: BULK + MORR) so the config-driven staging in stac_floodplains_bc can discover them. NEEXDZII (a geographic subset of BULK) is intentionally excluded to avoid overlapping catalog items.
- Gitignore `scripts/floodplain_lcc/logs/runs/` (per-run iteration output; curated evidence logs live directly under `logs/`).

## Related Issues
- Relates to NewGraphEnvironment/sred#35
- Prototype for #19 (disturbance attribution); STAC-side schema tracked in NewGraphEnvironment/stac_floodplains_bc#6

## Test plan
- [x] `run_area.R bulk 1,2,3` runs clean end-to-end (network → floodplain → LULC)
- [x] Coverage check: classified 2023 (514.5 km²) ≥ floodplain (490.5 km²) — full coverage, numbers trustworthy
- [x] `fire_tag.R bulk co_ff04` writes the `_fire` layer and reports the split

## Notes
BULK's `data/` outputs stay local (gitignored) on m1 for stac registration; the fire layer is held out of the STAC catalog until #19 + stac#6 land it uniformly across all groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
