### PR TITLE
Declare MORR publish targets (coho ff04 + chinook ff06)

### DIFF
--- a/config/morr/area.yml
+++ b/config/morr/area.yml
@@ -6,6 +6,13 @@ species: co
 min_order: 3
 schema: morr                   # dedicated persist schema
 primary_scenario: co_ff04      # headline scenario for LULC (03)
+# Publish targets for the STAC layer (stac_floodplains_bc): one item per (species, scenario).
+# MORR is modelled for both coho (ff04) and chinook — chinook's headline LULC extent is ff06,
+# not the ff04 default, so it is declared explicitly. WSGs without `targets` fall back to a
+# single {species, primary_scenario} item, so this is additive and backward compatible.
+targets:
+  - {species: co, scenario: co_ff04}
+  - {species: ch, scenario: ch_ff06}
 # OPEN QUESTION (resolve during the MORR run): does MORR run as the WHOLE watershed group,
 # or is it subset to a reach the way Neexdzii is subset from BULK? Default: whole WSG.
 subset: null


### PR DESCRIPTION
## Summary

Adds a `targets` list to `config/morr/area.yml` declaring MORR's two publish targets — coho `co_ff04` and chinook `ch_ff06`. MORR is modelled for both species; chinook's headline LULC extent is `ff06` (valley bottom), not the `ff04` default, so it is declared explicitly rather than inferred.

This is the source-of-truth for what the STAC publish layer emits per WSG. It is **additive and backward compatible**: areas without a `targets` list fall back to a single `{species, primary_scenario}` item, so the other 14 areas are unaffected.

## Why

The publish layer (`stac_floodplains_bc`) must not infer which scenario is a species' headline extent — that is a modelling decision and belongs in the area config. Consumed by stac_floodplains_bc#11 (multiple species items per watershed group). Pairs with the multi-species outputs from #23.

Relates to NewGraphEnvironment/stac_floodplains_bc#11, #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiSfXF2SP13JfD6V92pBws
