### PR TITLE
Enable per-watercourse attribution for the Skeena region (#40)

### DIFF
--- a/config/regions/skeena.yml
+++ b/config/regions/skeena.yml
@@ -11,4 +11,11 @@ region: skeena
 mergin_project: TBD              # doc-only; set when a Skeena field project exists
 min_order: 3
 species: [co]                    # coho only on these upper-Skeena groups
+# attribute_by (#40): also write a per-watercourse floodplain (<scenario>_by_gnis_name) for the
+# primary scenario, so "where is the floodplain of THIS river?" is answerable -- the question that
+# blocked Morice sampling. gnis_name rather than blue_line_key because the point here is a
+# human-readable watercourse name for field use; blue_line_key resolves every watercourse (no NA
+# group) for ~16% more time and is the better choice for analysis. Costs ~13 min per area on the
+# next step-2 run, primary scenario only. Remove this line to turn it off.
+attribute_by: gnis_name
 watershed_groups: [BULK, MORR]   # whole-WSG coho; NEEXDZII (subset of BULK) intentionally excluded


### PR DESCRIPTION
## Summary

One-line config change: `attribute_by: gnis_name` on `config/regions/skeena.yml`, so BULK and MORR write a `<scenario>_by_gnis_name` layer for the primary scenario on their next step-2 run.

Skeena is where the Morice fieldwork that motivated #40 sits. Other regions stay off until there is a question that needs them — attribution costs ~13 min per area, and it is a one-line change to enable later.

## Why `gnis_name` and not `blue_line_key`

The value here is a human-readable watercourse name for field use, and it matches the Morice deliverable already handed over. `blue_line_key` resolves every watercourse (no 320.6 km² NA group, which is 54% of MORR's summed area) for ~16% more time, and is the better choice for analysis. The tradeoff is documented in the region file itself so it is visible at the point of the decision rather than buried in an issue.

## Note for whoever republishes Skeena

`stac_floodplains_bc/scripts/01_stage.R:150` copies `floodplain.gpkg` wholesale, so a re-published BULK/MORR item's `floodplain` asset will gain this layer with **no STAC property describing it**. Harmless — the staging layer check tests for *missing* layers, not extra ones — but it is the same shape as NewGraphEnvironment/stac_floodplains_bc#6.

## A bug found while verifying this — filed as #44

`DRY=1 run_region.R skeena`, run purely to check the pass-through works, **rewrote `config/{bulk,morr}/` from `base_scenarios()`** — deleting MORR's six `ch_*` scenario rows, every citation in both groups' `flood_scenarios.csv`, and `config/morr/break_points.csv`. 50 deletions from a command documented as "plan only".

That directly undoes #23: after it, `FP_SPECIES=ch FP_PRIMARY_SCENARIO=ch_ff06 run_area.R morr` fails, even though `morr_ch_ff06` is published. The data survives; the config that reproduces it does not.

Those changes were **restored, not committed** — this branch is `config/regions/skeena.yml` only, 7 insertions. Filed as #44 with a suggested fix (merge rather than overwrite; make `DRY=1` actually dry).

## Verification

- [x] `skeena.yml` parses; `attribute_by: gnis_name` present
- [x] The #36 region→area pass-through carries it into `config/{bulk,morr}/area.yml` at run time — confirmed before the generated configs were reverted
- [x] Branch diff is one file, 7 insertions — no code change, no generated-config churn
- [x] MORR's `ch_*` rows, citations and `break_points.csv` verified intact on the branch

## Related Issues

- Follows #40 (capability + Morice deliverable, merged in #42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
