### PR TITLE
MORR whole-WSG sub-basin + blue_line_key attribution with name label (#48)

### DIFF
--- a/config/bulk/area.yml
+++ b/config/bulk/area.yml
@@ -11,6 +11,6 @@ min_order: 3
 schema: bulk                   # dedicated persist schema (never shared fresh.*, never neexdzii)
 primary_scenario: co_ff04      # headline scenario for LULC (03)
 subset: null                   # whole WSG — the group polygon is the single sub-basin
-attribute_by: gnis_name
+attribute_by: blue_line_key
 # flood_scenarios.csv copied from the coho scenario set (co_ff04 = functional floodplain).
 # No break_points.csv — whole-WSG single sub-basin.

--- a/config/morr/area.yml
+++ b/config/morr/area.yml
@@ -16,6 +16,6 @@ targets:
 # OPEN QUESTION (resolve during the MORR run): does MORR run as the WHOLE watershed group,
 # or is it subset to a reach the way Neexdzii is subset from BULK? Default: whole WSG.
 subset: null
-attribute_by: gnis_name
+attribute_by: blue_line_key
 # flood_scenarios.csv / break_points.csv in this dir are copied from Neexdzii as a starting
 # template — review the flood_factor scenarios and (re)place the sub-basin break points for MORR.

--- a/config/morr/break_points.csv
+++ b/config/morr/break_points.csv
@@ -1,2 +1,0 @@
-id,lon,lat,blk,drm,gnis_name,dist_m,name_basin,fisheries_value,falls_downstream,description
-1,-126.746442,54.410770,360885316,61.99551,Morice River,0,Morice,5,0,MORR whole-watershed-group outlet — Morice River mainstem at the Bulkley (Wedzin Kwa) confluence. Single break point => one sub-basin covering the entire MORR group (verified 4382.2 km2 vs 4379.1 km2 group area; captures 4877/4877 coho order-3+ segments). Interior sub-basin delineation deferred to a later pass (issue #1 Phase 3).

--- a/config/regions/skeena.yml
+++ b/config/regions/skeena.yml
@@ -11,11 +11,20 @@ region: skeena
 mergin_project: TBD              # doc-only; set when a Skeena field project exists
 min_order: 3
 species: [co]                    # coho only on these upper-Skeena groups
-# attribute_by (#40): also write a per-watercourse floodplain (<scenario>_by_gnis_name) for the
+# attribute_by (#40): also write a per-watercourse floodplain (<scenario>_by_blue_line_key) for the
 # primary scenario, so "where is the floodplain of THIS river?" is answerable -- the question that
-# blocked Morice sampling. gnis_name rather than blue_line_key because the point here is a
-# human-readable watercourse name for field use; blue_line_key resolves every watercourse (no NA
-# group) for ~16% more time and is the better choice for analysis. Costs ~13 min per area on the
-# next step-2 run, primary scenario only. Remove this line to turn it off.
-attribute_by: gnis_name
+# blocked Morice sampling.
+#
+# blue_line_key, NOT gnis_name (#48). gnis_name reads better but answers the question for barely a
+# third of the ground: on MORR it yields 33 rows and pools 320.6 km2 -- 78% of the floodplain -- into
+# a single unnamed feature, so a click anywhere in it returns NA. The channels hidden in there are
+# not slivers (largest carry 20.1, 19.6, 17.1 km of network). blue_line_key resolves all 340 with no
+# NA group, and loses nothing: on MORR every named river is exactly ONE blue_line_key (Morice
+# 360885316, Thautil 360882037, ...) and no key carries two names, so it is a strict refinement.
+# Readability is recovered by the carried gnis_name label column rather than by grouping on the name.
+#
+# Cost is not the tradeoff it looks like: 85% of attribution is k-independent (0.39 s per extra
+# group, measured on MORR at 16.5M cells), so 307 extra groups is ~2 minutes on a ~15 min pass.
+# Primary scenario only. Remove this line to turn it off.
+attribute_by: blue_line_key
 watershed_groups: [BULK, MORR]   # whole-WSG coho; NEEXDZII (subset of BULK) intentionally excluded

--- a/scripts/floodplain_lcc/02_floodplain_model.R
+++ b/scripts/floodplain_lcc/02_floodplain_model.R
@@ -208,6 +208,29 @@ fp_floodplain <- function(cfg, scenarios = "run") {
       attributed$wsg      <- cfg$watershed_group
       attributed$species  <- cfg$species
       attributed$scenario <- sc$scenario_id
+      # Label column (#48): grouping by an opaque key (blue_line_key) resolves every watercourse,
+      # but a click in QGIS then returns `360885316` rather than "Morice River" -- complete and
+      # unusable in the field. Carry the human-readable name alongside when the network offers one
+      # that is a clean function of the grouping key: on MORR all 340 keys map to 0 or 1 gnis_name,
+      # so 33 rows get a name and 307 are honestly NA. Skipped (with a message) when the mapping is
+      # ambiguous, rather than picking one name arbitrarily and quietly mislabelling a watercourse.
+      label_col <- "gnis_name"
+      if (!identical(cfg$attribute_by, label_col) &&
+            label_col %in% setdiff(names(streams), attr(streams, "sf_column"))) {
+        lut <- unique(sf::st_drop_geometry(streams)[, c(cfg$attribute_by, label_col)])
+        lut <- lut[!is.na(lut[[label_col]]), , drop = FALSE]
+        n_per_key <- tapply(lut[[label_col]], lut[[cfg$attribute_by]], function(x) length(unique(x)))
+        if (any(n_per_key > 1)) {
+          message("  Label: skipped -- ", sum(n_per_key > 1), " ", cfg$attribute_by,
+                  " value(s) carry more than one ", label_col, "; not guessing")
+        } else {
+          lut <- lut[!duplicated(lut[[cfg$attribute_by]]), , drop = FALSE]
+          attributed[[label_col]] <- lut[[label_col]][match(attributed[[cfg$attribute_by]],
+                                                            lut[[cfg$attribute_by]])]
+          message("  Label: ", sum(!is.na(attributed[[label_col]])), " of ", nrow(attributed),
+                  " groups carry a ", label_col)
+        }
+      }
       attr_lyr <- paste0(sc$scenario_id, "_by_", cfg$attribute_by)
       sf::st_write(attributed, out_gpkg, layer = attr_lyr,
                    append = file.exists(out_gpkg), delete_layer = TRUE, quiet = TRUE)

--- a/scripts/floodplain_lcc/fp_region.R
+++ b/scripts/floodplain_lcc/fp_region.R
@@ -86,7 +86,10 @@ fp_region_plan <- function(cfg_dir, region_owned, base) {
       area_mode <- "none"; area_action <- "unchanged"
     } else {
       area_mode <- "update"
-      area_action <- paste0("update: ", paste(c(set_keys, paste0("-", rm_keys)), collapse = ", "))
+      # paste0("-", character(0)) is "-", NOT character(0) -- a zero-length argument is treated as
+      # "" rather than short-circuiting, so an unguarded paste prints a phantom removed key.
+      removed <- if (length(rm_keys)) paste0("-", rm_keys) else character(0)
+      area_action <- paste0("update: ", paste(c(set_keys, removed), collapse = ", "))
     }
   }
 

--- a/scripts/floodplain_lcc/region_config-check.R
+++ b/scripts/floodplain_lcc/region_config-check.R
@@ -59,6 +59,13 @@ message("\n#44 acceptance: a region run preserves hand-maintained area config")
 # MORR is the worst case: two species, 12 citations, and a break_points.csv that decides which
 # sub-basin branch step 2 takes. skeena.yml resolves it to coho with attribute_by = gnis_name.
 d <- copy_cfg("morr")
+# Synthesize the break_points.csv rather than depending on MORR shipping one. The real config lost
+# its break points in #48, which broke this check when it was coupled to the fixture -- the rule
+# ("a region run never deletes break_points.csv") is what matters, not which area happens to carry
+# one today. Construct the condition under test.
+writeLines(c("id,lon,lat,blk,drm,gnis_name,dist_m,name_basin,fisheries_value,falls_downstream,description",
+             "1,-126.7,54.4,360885316,0,Test Creek,0,Test,5,0,synthetic fixture for the guard"),
+           fs::path(d, "break_points.csv"))
 before_csv <- readr::read_csv(fs::path(d, "flood_scenarios.csv"), show_col_types = FALSE)
 # Compare the FILE, not two read_csv results: tibbles carry `spec`/`problems` attributes that differ
 # between reads of the same bytes, so identical() on them tests the reader, not the file.
@@ -139,8 +146,14 @@ ok("comment lines survive an update",
    sum(grepl("^\\s*#", after_lines)) == n_comments, paste(n_comments, "comments"))
 ok("the added region-owned key is present",
    identical(yaml::read_yaml(fs::path(d, "area.yml"))$attribute_by, "gnis_name"))
-ok("only added lines changed; nothing else was re-emitted",
-   all(before_lines %in% after_lines), paste(length(after_lines) - length(before_lines), "line(s) added"))
+# The rule is not "every original line survives" -- a region run is ALLOWED to rewrite a
+# region-owned key's line in place, and does so whenever the region changes that value. What it must
+# never touch is everything else: comments, blank lines, and area-owned keys. Assert that, or the
+# check fails the moment an area happens to already carry the key under test (it did, on bulk).
+owned_line <- function(l) any(vapply(FP_REGION_OWNED, function(k) grepl(paste0("^", k, ":"), l), logical(1)))
+untouchable <- before_lines[!vapply(before_lines, owned_line, logical(1))]
+ok("nothing outside the region-owned keys was re-emitted",
+   all(untouchable %in% after_lines), paste(length(untouchable), "non-owned line(s) checked"))
 
 # A changed value is edited in place, and its trailing comment stays with it.
 d <- copy_cfg("bulk")


### PR DESCRIPTION
## Summary

Two independent things, both small:

- **#48** — MORR drops `break_points.csv` (whole-WSG sub-basin like every other batch area), and the
  skeena region switches per-watercourse attribution from `gnis_name` to `blue_line_key` with a
  carried name label.
- **#44 follow-ups** — a phantom removed-key in the reconciliation report, and two guard assertions
  that were coupled to the contents of `config/` rather than to the rule they claim to test.

## A correction I have to carry forward

**I claimed deleting `break_points.csv` would clear the 4.61 km² of MORR floodplain sitting inside
BULK. It does not, and commit `6e1d314`'s message states the wrong causality.** Measured after the
run:

| | before | after |
|---|---|---|
| sub-basin | 4382.2 km² | **4379.1 km²** ✓ changed |
| `co_ff04` floodplain | 411.1 km² | **411.1 km²** — unchanged |
| of which inside BULK | 4.61 km² | **4.61 km²** — unchanged |

`02_floodplain_model.R:106` derives the delineation AOI from `streams`, not from `subbasins` — the
sub-basin is written for step-3 reporting and never constrains the VCA. The 3.14 km² sub-basin
sliver and the 4.61 km² floodplain overlap are two different quantities with two different causes;
their similar size made them look like one thing.

The deletion is still right for the reasons that survive: it removes a vestige copied from Neexdzii
(`morr/area.yml` said so), makes MORR consistent with every other whole-WSG area, matches what
`CLAUDE.md` already claimed MORR was, and fixes a 3.1 km² over-reach that fed sub-basin reporting.
Cross-group overlap is filed separately as **#53**, correctly attributed. #48's body carries the same
correction.

## Why `blue_line_key`

`gnis_name` was answering the question for barely a third of the ground. The decisive measurement was
not the unnamed bucket — it was this:

> **The Morice's blue line is 134.0 km. Only 91.7 km carries the name "Morice River".**

A third of the river's own mainstem is unnamed, so name-grouping stripped 42.3 km of the Morice out
of the Morice and put it in the NA blob. Systemic: across all 33 named blue lines, 68.0 of 642.5 km
(11%) is unnamed.

| | `gnis_name` | `blue_line_key` |
|---|---|---|
| rows | 33 | **340** |
| unnamed/NA group | 320.6 km² in one row | **none** |
| Morice floodplain | 56.0 km² | **138.5 km²** |

Nothing is lost: every named river is exactly one key, and no key carries two names, so it is a
strict refinement. Readability comes back as a **carried `gnis_name` column** rather than by grouping
on the name — so every row keeps its key *and* gains a name where one exists (33 of 340). The label
is skipped with a message if the key-to-name mapping is ever ambiguous, rather than mislabelling a
watercourse by picking one.

Cost was not the tradeoff it looked like: 85% of attribution is k-independent (0.39 s per extra
group), so 307 extra groups is ~2 minutes on a ~15 min pass.

## The #44 follow-ups

- `paste0("-", character(0))` returns `"-"`, not `character(0)` — a zero-length argument is treated
  as `""` rather than short-circuiting, so a run with nothing to remove reported a removal that had
  not happened.
- **Both guard fixes were found by the guard failing**, which is it working. Deleting
  `break_points.csv` broke the assertion that MORR keeps one — it now synthesizes the file, so it
  tests the rule and not the fixture. And "every original line survives" was too strict: a region run
  *is* allowed to rewrite a region-owned key in place, and did once `bulk/area.yml` had
  `attribute_by`. Narrowed to what must hold — nothing outside the region-owned keys is re-emitted.

## Test plan

- [x] MORR coho steps 2–3 run clean: **0 error markers**, all three outputs rewritten (mtime newer
      than a run-start marker), not stale
- [x] `co_ff04_by_blue_line_key`: **340 rows, 0 null keys, 33 carrying a name**
- [x] `region_config-check.R`: 27 checks green
- [x] Sub-basin confirmed changed to the FWA group polygon (4379.1 km²)
- [x] Morice sampling frame re-cut: 138.49 km² = 66.76 exclusive + 71.73 shared

## Known gaps, filed not fixed

- **#53** cross-group floodplain overlap — also flags that the Fraser total in `README.md`
  (3,366 km² across 10 groups) is a sum of possibly-overlapping polygons, not a union
- **#54** patch↔watercourse bridge, **#55** stale transition layers — both needed before a STAC
  rebuild, both out of scope here

## Related

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
