### PR TITLE
Remodel under flooded 0.5.0, GRAB from the rebuilt fresh network, fix per-sub-basin patch_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,12 +135,25 @@ Coexistence is data-layer only (steps 01/02/03).
 
 ## Areas
 
-- `neexdzii` — **parity fixture** (coho, BULK subset). The generalized pipeline must reproduce the
-  known-good numbers (coho-3 network 678.2 km, floodplain co_ff04 171.0 km², floodplain tree loss
-  943.13 ha, within ~0.004% VCA noise) before any new area is trusted. Verified.
-- `morr` — Morice watershed group (whole WSG). **Coho + chinook coexist** in `data/morr/` (#23):
-  coho floodplain co_ff04 411.1 km², tree loss 433.8 ha (burned to `restoration_wedzin_kwa` Mergin);
-  chinook ch_ff06 (valley bottom) 432.4 km², tree loss 482.4 ha. Fire attribution ~6% of loss (both).
+- `neexdzii` — **parity fixture** (coho, BULK subset). The pipeline must reproduce the known-good
+  numbers before any new area is trusted.
+  **Re-baselined 2026-09-01** — coho-3 network **673.5 km**, floodplain `co_ff04` **142.8 km²**,
+  floodplain tree loss **770.0 ha**. The previous contract (678.2 km / 171.0 km² / 943.13 ha) is
+  **dead, not merely superseded**: it was produced by flooded ≤ 0.4.1, whose bankfull regression was
+  fed hectares where Hall et al. specify km² and mm where they specify cm/yr — width 8.22× and depth
+  3.59× too large on every run the package ever did, so `ff04` was delineating ~14.4× bankfull depth
+  against Hall's field-validated 3. Two things moved at once (flooded 0.5.0 **and** the switch to
+  link's rebuilt `fresh` network), so the change cannot be attributed to either alone — but the
+  network moved 0.7% and the floodplain 16.5%, so the bankfull fix dominates.
+  **The retention corroborates independently:** neexdzii keeps **83.5%** of its old `co_ff04`, and
+  flooded's own NEWS reports **84.7%** for Parsnip on MRDEM-30 — a different watershed, same DEM,
+  within 1.2 points. Record the new numbers as a fresh contract, never as a delta from the old.
+- `morr` — Morice watershed group (whole WSG). **Coho + chinook coexist** in `data/morr/` (#23).
+  **Remodelled 2026-09-01** (flooded 0.5.0 + `fresh` network): coho `co_ff04` **357.7 km²**
+  (87.0% of the old 411.1), tree loss **308.7 ha**; chinook `ch_ff06` **371.6 km²** (85.9% of 432.4),
+  tree loss **342.6 ha**. `ch_ff06` and `co_ff06` are **identical** — MORR's coho and chinook
+  accessible networks are the same 4,877 segments, so species differs only in which scenario is
+  primary.
 - `ufra` — Upper Fraser (**chinook** — coho is unmodelled up there; `access_ch` exists). Run:
   floodplain ch_ff04 188.2 km², tree loss 544.5 ha. Burned to `sern_fraser_2024` Mergin.
 

--- a/config/bowr/area.yml
+++ b/config/bowr/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: bowr
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/bowr/area.yml
+++ b/config/bowr/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: bowr
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/bulk/area.yml
+++ b/config/bulk/area.yml
@@ -12,5 +12,6 @@ schema: bulk                   # dedicated persist schema (never shared fresh.*,
 primary_scenario: co_ff04      # headline scenario for LULC (03)
 subset: null                   # whole WSG — the group polygon is the single sub-basin
 attribute_by: blue_line_key
+network_source: fresh
 # flood_scenarios.csv copied from the coho scenario set (co_ff04 = functional floodplain).
 # No break_points.csv — whole-WSG single sub-basin.

--- a/config/fran/area.yml
+++ b/config/fran/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: fran
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/fran/area.yml
+++ b/config/fran/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: fran
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/kisp/area.yml
+++ b/config/kisp/area.yml
@@ -13,5 +13,6 @@ min_order: 3
 schema: kisp                   # dedicated persist schema
 primary_scenario: ch_ff04      # headline scenario for LULC (03)
 subset: null                   # whole WSG — the FWA group polygon is the single sub-basin
+network_source: fresh
 # flood_scenarios.csv carries the chinook scenario set (ch_ff02/04/06 run=TRUE).
 # No break_points.csv — whole-WSG single sub-basin.

--- a/config/kisp/area.yml
+++ b/config/kisp/area.yml
@@ -14,5 +14,6 @@ schema: kisp                   # dedicated persist schema
 primary_scenario: ch_ff04      # headline scenario for LULC (03)
 subset: null                   # whole WSG — the FWA group polygon is the single sub-basin
 network_source: fresh
+attribute_by: blue_line_key
 # flood_scenarios.csv carries the chinook scenario set (ch_ff02/04/06 run=TRUE).
 # No break_points.csv — whole-WSG single sub-basin.

--- a/config/lchl/area.yml
+++ b/config/lchl/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: lchl
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/lchl/area.yml
+++ b/config/lchl/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: lchl
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/lsal/area.yml
+++ b/config/lsal/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: lsal
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/lsal/area.yml
+++ b/config/lsal/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: lsal
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/mcgr/area.yml
+++ b/config/mcgr/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: mcgr
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/mcgr/area.yml
+++ b/config/mcgr/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: mcgr
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/mork/area.yml
+++ b/config/mork/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: mork
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/mork/area.yml
+++ b/config/mork/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: mork
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/morr/area.yml
+++ b/config/morr/area.yml
@@ -17,5 +17,6 @@ targets:
 # or is it subset to a reach the way Neexdzii is subset from BULK? Default: whole WSG.
 subset: null
 attribute_by: blue_line_key
+network_source: fresh
 # flood_scenarios.csv / break_points.csv in this dir are copied from Neexdzii as a starting
 # template — review the flood_factor scenarios and (re)place the sub-basin break points for MORR.

--- a/config/necr/area.yml
+++ b/config/necr/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: necr
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/necr/area.yml
+++ b/config/necr/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: necr
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/neexdzii/area.yml
+++ b/config/neexdzii/area.yml
@@ -7,6 +7,17 @@ watershed_group: BULK          # link aoi — runs the whole WSG, then subset be
 species: co
 min_order: 3                   # minimum stream order for the floodplain-input network
 schema: neexdzii               # dedicated persist schema (never shared fresh.*)
+# network_source: GRAB from `fresh`, matching every other area (see skeena.yml for the rationale).
+# neexdzii is deliberately NOT in a region file, so this is hand-set here and survives -- run_region
+# never rewrites an area.yml it does not own (#44).
+#
+# NOTE FOR THE PARITY BASELINE: this changes the network AND flooded changed the delineation
+# (0.5.0 -- the bankfull units fix, every earlier floodplain over-mapped). So the old known-good
+# numbers (678.2 km network / 171.0 km2 co_ff04 / 943.13 ha tree loss) die for TWO reasons at once
+# and the movement cannot be attributed to either alone. They were produced by code now known wrong,
+# so there is nothing to preserve -- but the new baseline must be recorded as a fresh contract, not
+# as a delta from the old one.
+network_source: fresh
 primary_scenario: co_ff04      # headline scenario for LULC (03) + parity check (171.0 km²)
 # Neexdzii is a reach of BULK: keep only the network upstream of the Wedzin Kwa confluence.
 subset:

--- a/config/neexdzii/area.yml
+++ b/config/neexdzii/area.yml
@@ -18,6 +18,8 @@ schema: neexdzii               # dedicated persist schema (never shared fresh.*)
 # so there is nothing to preserve -- but the new baseline must be recorded as a fresh contract, not
 # as a delta from the old one.
 network_source: fresh
+# attribute_by: hand-set here -- neexdzii is deliberately outside every region file (#44).
+attribute_by: blue_line_key
 primary_scenario: co_ff04      # headline scenario for LULC (03) + parity check (171.0 km²)
 # Neexdzii is a reach of BULK: keep only the network upstream of the Wedzin Kwa confluence.
 subset:

--- a/config/pars/area.yml
+++ b/config/pars/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: pars
 primary_scenario: bt_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/pars/area.yml
+++ b/config/pars/area.yml
@@ -4,3 +4,4 @@ species: bt
 min_order: 3
 schema: pars
 primary_scenario: bt_ff04
+network_source: fresh

--- a/config/pcea/area.yml
+++ b/config/pcea/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: pcea
 primary_scenario: bt_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/pcea/area.yml
+++ b/config/pcea/area.yml
@@ -4,3 +4,4 @@ species: bt
 min_order: 3
 schema: pcea
 primary_scenario: bt_ff04
+network_source: fresh

--- a/config/pine/area.yml
+++ b/config/pine/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: pine
 primary_scenario: bt_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/pine/area.yml
+++ b/config/pine/area.yml
@@ -4,3 +4,4 @@ species: bt
 min_order: 3
 schema: pine
 primary_scenario: bt_ff04
+network_source: fresh

--- a/config/regions/fraser.yml
+++ b/config/regions/fraser.yml
@@ -23,4 +23,9 @@ species: [ch, bt]          # ordered: chinook, then bull trout
 # records the comparison, but a pass here is not evidence of freshness the way it is for columbia
 # (which grabs from `fresh_default`, a genuinely different schema).
 network_source: fresh
+# attribute_by (#40, #54): also write a per-watercourse floodplain and the patch<->watercourse
+# bridge for the primary scenario. blue_line_key rather than gnis_name -- on MORR, name-grouping
+# pooled 78% of the floodplain into one unnamed feature because a third of the Morice mainstem
+# itself carries no gnis_name. The name is carried as a label column instead (#48).
+attribute_by: blue_line_key
 watershed_groups: [LCHL, LSAL, WILL, TABR, UFRA, NECR, MORK, FRAN, BOWR, MCGR]

--- a/config/regions/fraser.yml
+++ b/config/regions/fraser.yml
@@ -7,4 +7,20 @@ region: fraser
 mergin_project: newgraph/sern_fraser_2024
 min_order: 3
 species: [ch, bt]          # ordered: chinook, then bull trout
+# network_source (#52): GRAB from `fresh` -- link's province-wide rebuild, 2026-08-31/09-01.
+# The per-WSG schemas (morr/bulk/necr/pars) hold July networks and were NOT touched by that rebuild
+# (streams last analyzed 2026-07-09..19), so BUILDing there would ignore the rebuild entirely.
+#
+# Provenance is per-WSG ROWS in `fresh.log`, keyed by watershed_group_code -- not a log table inside
+# each persist schema. Read it with `link::lnk_log_read(conn, lnk_config("default"), aoi = "<WSG>")`,
+# which is authoritative; introspecting information_schema for per-schema log tables finds nothing
+# and reads as "no provenance", which is wrong. All four target WSGs return one row each carrying
+# `config_hash` (sha256:19e3a...), the value #52's provenance table records.
+#
+# CAVEAT ON THE GUARD: the freshness guard compares grabbed km against `fresh.streams_vw_bcfp`
+# (01_network_extract.R:143). Grabbing FROM `fresh` makes that a schema compared against a view over
+# itself -- it passes at ~0% deviation and verifies nothing. Left at the default so the stamp still
+# records the comparison, but a pass here is not evidence of freshness the way it is for columbia
+# (which grabs from `fresh_default`, a genuinely different schema).
+network_source: fresh
 watershed_groups: [LCHL, LSAL, WILL, TABR, UFRA, NECR, MORK, FRAN, BOWR, MCGR]

--- a/config/regions/peace.yml
+++ b/config/regions/peace.yml
@@ -28,4 +28,9 @@ species: [bt]                    # bull trout only (ch unmodelled on the Arctic 
 # records the comparison, but a pass here is not evidence of freshness the way it is for columbia
 # (which grabs from `fresh_default`, a genuinely different schema).
 network_source: fresh
+# attribute_by (#40, #54): also write a per-watercourse floodplain and the patch<->watercourse
+# bridge for the primary scenario. blue_line_key rather than gnis_name -- on MORR, name-grouping
+# pooled 78% of the floodplain into one unnamed feature because a third of the Morice mainstem
+# itself carries no gnis_name. The name is carried as a label column instead (#48).
+attribute_by: blue_line_key
 watershed_groups: [PCEA, PARS, PINE]   # PINE built; see pre-pass caveat above

--- a/config/regions/peace.yml
+++ b/config/regions/peace.yml
@@ -12,4 +12,20 @@ region: peace
 mergin_project: TBD              # doc-only; set when a Peace field project exists
 min_order: 3
 species: [bt]                    # bull trout only (ch unmodelled on the Arctic slope)
+# network_source (#52): GRAB from `fresh` -- link's province-wide rebuild, 2026-08-31/09-01.
+# The per-WSG schemas (morr/bulk/necr/pars) hold July networks and were NOT touched by that rebuild
+# (streams last analyzed 2026-07-09..19), so BUILDing there would ignore the rebuild entirely.
+#
+# Provenance is per-WSG ROWS in `fresh.log`, keyed by watershed_group_code -- not a log table inside
+# each persist schema. Read it with `link::lnk_log_read(conn, lnk_config("default"), aoi = "<WSG>")`,
+# which is authoritative; introspecting information_schema for per-schema log tables finds nothing
+# and reads as "no provenance", which is wrong. All four target WSGs return one row each carrying
+# `config_hash` (sha256:19e3a...), the value #52's provenance table records.
+#
+# CAVEAT ON THE GUARD: the freshness guard compares grabbed km against `fresh.streams_vw_bcfp`
+# (01_network_extract.R:143). Grabbing FROM `fresh` makes that a schema compared against a view over
+# itself -- it passes at ~0% deviation and verifies nothing. Left at the default so the stamp still
+# records the comparison, but a pass here is not evidence of freshness the way it is for columbia
+# (which grabs from `fresh_default`, a genuinely different schema).
+network_source: fresh
 watershed_groups: [PCEA, PARS, PINE]   # PINE built; see pre-pass caveat above

--- a/config/regions/skeena.yml
+++ b/config/regions/skeena.yml
@@ -27,4 +27,20 @@ species: [co]                    # coho only on these upper-Skeena groups
 # group, measured on MORR at 16.5M cells), so 307 extra groups is ~2 minutes on a ~15 min pass.
 # Primary scenario only. Remove this line to turn it off.
 attribute_by: blue_line_key
+# network_source (#52): GRAB from `fresh` -- link's province-wide rebuild, 2026-08-31/09-01.
+# The per-WSG schemas (morr/bulk/necr/pars) hold July networks and were NOT touched by that rebuild
+# (streams last analyzed 2026-07-09..19), so BUILDing there would ignore the rebuild entirely.
+#
+# Provenance is per-WSG ROWS in `fresh.log`, keyed by watershed_group_code -- not a log table inside
+# each persist schema. Read it with `link::lnk_log_read(conn, lnk_config("default"), aoi = "<WSG>")`,
+# which is authoritative; introspecting information_schema for per-schema log tables finds nothing
+# and reads as "no provenance", which is wrong. All four target WSGs return one row each carrying
+# `config_hash` (sha256:19e3a...), the value #52's provenance table records.
+#
+# CAVEAT ON THE GUARD: the freshness guard compares grabbed km against `fresh.streams_vw_bcfp`
+# (01_network_extract.R:143). Grabbing FROM `fresh` makes that a schema compared against a view over
+# itself -- it passes at ~0% deviation and verifies nothing. Left at the default so the stamp still
+# records the comparison, but a pass here is not evidence of freshness the way it is for columbia
+# (which grabs from `fresh_default`, a genuinely different schema).
+network_source: fresh
 watershed_groups: [BULK, MORR]   # whole-WSG coho; NEEXDZII (subset of BULK) intentionally excluded

--- a/config/regions/skeena_ch.yml
+++ b/config/regions/skeena_ch.yml
@@ -12,4 +12,9 @@ species: [ch]                    # chinook
 # network_source: GRAB from `fresh` -- see skeena.yml for the full rationale and the guard caveat.
 # Provenance is per-WSG rows in `fresh.log`; read with link::lnk_log_read(conn, cfg, aoi = "KISP").
 network_source: fresh
+# attribute_by (#40, #54): also write a per-watercourse floodplain and the patch<->watercourse
+# bridge for the primary scenario. blue_line_key rather than gnis_name -- on MORR, name-grouping
+# pooled 78% of the floodplain into one unnamed feature because a third of the Morice mainstem
+# itself carries no gnis_name. The name is carried as a label column instead (#48).
+attribute_by: blue_line_key
 watershed_groups: [KISP]         # Kispiox River

--- a/config/regions/skeena_ch.yml
+++ b/config/regions/skeena_ch.yml
@@ -9,4 +9,7 @@ region: skeena
 mergin_project: TBD              # doc-only; set when a Skeena field project exists
 min_order: 3
 species: [ch]                    # chinook
+# network_source: GRAB from `fresh` -- see skeena.yml for the full rationale and the guard caveat.
+# Provenance is per-WSG rows in `fresh.log`; read with link::lnk_log_read(conn, cfg, aoi = "KISP").
+network_source: fresh
 watershed_groups: [KISP]         # Kispiox River

--- a/config/tabr/area.yml
+++ b/config/tabr/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: tabr
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/tabr/area.yml
+++ b/config/tabr/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: tabr
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/ufra/area.yml
+++ b/config/ufra/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: ufra
 primary_scenario: ch_ff04
+network_source: fresh

--- a/config/ufra/area.yml
+++ b/config/ufra/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: ufra
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/will/area.yml
+++ b/config/will/area.yml
@@ -5,3 +5,4 @@ min_order: 3
 schema: will
 primary_scenario: ch_ff04
 network_source: fresh
+attribute_by: blue_line_key

--- a/config/will/area.yml
+++ b/config/will/area.yml
@@ -4,3 +4,4 @@ species: ch
 min_order: 3
 schema: will
 primary_scenario: ch_ff04
+network_source: fresh

--- a/scripts/floodplain_lcc/03_lulc_classify.R
+++ b/scripts/floodplain_lcc/03_lulc_classify.R
@@ -189,7 +189,14 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
     if (!is.na(attr_lyr) && file.exists(fp_file) && attr_lyr %in% sf::st_layers(fp_file)$name) {
       key <- cfg$attribute_by
       wc  <- sf::st_read(fp_file, layer = attr_lyr, quiet = TRUE)[, key]
-      pat <- trans_polys[, c("patch_id", "area_ha")]
+      # patch_id is a PER-SUB-BASIN key, not a global one: dft_transition_vectors numbers patches
+      # within each sub-basin, so a multi-sub-basin area repeats ids across basins (neexdzii: 2032
+      # rows, 1973 distinct ids, 13 sub-basins). Every whole-WSG area has ONE sub-basin, which makes
+      # patch_id look globally unique and hides this until the first subset area runs. Grouping on it
+      # alone pools rows from different patches and silently mis-apportions -- the same
+      # per-tenant-key-against-a-multi-tenant-table trap code-check.md records for id_segment.
+      pat <- trans_polys[, c("patch_id", "name_basin", "area_ha")]
+      pat$patch_key <- paste(pat$name_basin, pat$patch_id, sep = "\u00a6")
       # The two layers are in DIFFERENT projected CRS -- the attribution layer inherits the stream
       # network's BC Albers, the transition layer the landcover raster's UTM -- so st_intersection
       # errors outright. Transform the watercourses TO the patches, not the reverse: area_ha was
@@ -205,6 +212,7 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
         ov_ha  <- as.numeric(sf::st_area(inter)) / 1e4
         bridge <- data.frame(
           patch_id     = inter$patch_id,
+          name_basin   = inter$name_basin,
           k            = inter[[key]],
           overlap_ha   = round(ov_ha, 4),
           # Capped at 1: a fully contained patch can overshoot by a float epsilon, and a fraction
@@ -220,9 +228,9 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
         #   apportion_weight  "what share of this patch is credited to it?"            (sums to 1)
         # Ship both: the first answers whether a patch belongs to a river, the second is the only
         # one that reconciles to an ungrouped total.
-        tot_ov <- tapply(bridge$overlap_ha, bridge$patch_id, sum)
-        bridge$apportion_weight <- round(
-          bridge$overlap_ha / tot_ov[as.character(bridge$patch_id)], 4)
+        pk <- paste(bridge$name_basin, bridge$patch_id, sep = "\u00a6")
+        tot_ov <- tapply(bridge$overlap_ha, pk, sum)
+        bridge$apportion_weight <- round(bridge$overlap_ha / tot_ov[pk], 4)
         names(bridge)[names(bridge) == "k"] <- key
         # A shared boundary yields a zero-area pair: a join artefact, not a relationship. Keeping it
         # would inflate the row count without changing any sum.
@@ -235,12 +243,12 @@ fp_lulc <- function(cfg, scenario = cfg$primary_scenario) {
         # whether ground was missed. max(overlap_frac) under ~0.97 means patch boundaries and
         # attribution boundaries are drifting apart (they come off different raster grids), and a
         # sharp drop would mean the join is quietly losing ground.
-        u <- tapply(bridge$overlap_frac, bridge$patch_id, max)
+        u <- tapply(bridge$overlap_frac, pk, max)
         message("  Layer: ", b_lyr, " (", nrow(bridge), " pairs over ",
-                length(unique(bridge$patch_id)), " patches and ",
+                length(unique(pk)), " patches and ",
                 length(unique(bridge[[key]])), " watercourses; union coverage ",
                 sprintf("%.3f", mean(u)),
-                ", unbridged patches ", sum(!pat$patch_id %in% bridge$patch_id), ")")
+                ", unbridged patches ", sum(!pat$patch_key %in% pk), ")")
       }
     }
   }

--- a/scripts/floodplain_lcc/attribute_tag.R
+++ b/scripts/floodplain_lcc/attribute_tag.R
@@ -1,0 +1,132 @@
+# attribute_tag.R — add per-watercourse attribution (and its bridge) to an EXISTING delineation.
+#
+# `attribute_by` produces two things nothing else does: `<scenario>_by_<key>`, the floodplain split
+# one row per watercourse, and `patch_watercourse_<scenario>_<span>`, the bridge that lets change
+# patches be summed per river (#40, #54). Both are written mid-pipeline — the attribution in step 2,
+# the bridge in step 3 — so an area whose region file lacked `attribute_by` at run time has neither,
+# and getting them has meant re-running both steps.
+#
+# It does not have to. Step 2 already saves the delineation as `floodplain_<scenario>.tif`, and that
+# raster plus the stream network is everything `fl_valley_attribute()` needs. Re-running step 2 would
+# recompute a VCA we already have — the expensive part — to arrive at the same answer.
+#
+# So this is the `fire_tag.R` shape: re-derive one product from what is on disk without repeating the
+# work that produced it. Cost is the attribution itself (~15 min on a large group) rather than hours.
+#
+# Writes only NEW layers. The delineation, the transition layer and their numbers are untouched, so
+# this cannot move a figure that has already been verified or published.
+#
+# usage: Rscript scripts/floodplain_lcc/attribute_tag.R <area> [scenario]
+#        scenario defaults to the area's primary_scenario.
+
+suppressMessages({library(sf); library(terra); library(yaml); library(readr)})
+sf::sf_use_s2(FALSE)
+source(here::here("scripts", "fp_gpkg.R")); fp_gpkg_pin_date()   # #45: keep writes deterministic
+
+a    <- commandArgs(TRUE)
+area <- a[1]
+if (is.na(area)) stop("usage: Rscript attribute_tag.R <area> [scenario]", call. = FALSE)
+
+cfg_dir <- here::here("config", area)
+cfg     <- yaml::read_yaml(file.path(cfg_dir, "area.yml"))
+scen_tb <- readr::read_csv(file.path(cfg_dir, "flood_scenarios.csv"), show_col_types = FALSE)
+scenario <- if (!is.na(a[2])) a[2] else (cfg$primary_scenario %||% paste0(cfg$species, "_ff04"))
+`%||%` <- function(x, y) if (is.null(x)) y else x
+
+key <- cfg$attribute_by
+if (is.null(key) || !nzchar(key)) {
+  stop("area '", area, "' has no attribute_by. It is region-owned: set it in the region file so the ",
+       "output is reproducible, then re-run. An env override would leave these layers unexplainable.",
+       call. = FALSE)
+}
+sc <- scen_tb[scen_tb$scenario_id == scenario, ]
+if (nrow(sc) != 1L) stop("scenario '", scenario, "' not found in ", area, "/flood_scenarios.csv",
+                         call. = FALSE)
+
+out_dir  <- here::here("data", area)
+fp_gpkg  <- file.path(out_dir, "floodplain.gpkg")
+lc_gpkg  <- file.path(out_dir, "floodplain_landcover.gpkg")
+tif      <- file.path(out_dir, paste0("floodplain_", scenario, ".tif"))
+net_gpkg <- file.path(out_dir, "aquatic_network.gpkg")
+if (!file.exists(tif)) stop("no saved delineation raster: ", basename(tif),
+                            " -- run step 2 for this scenario first.", call. = FALSE)
+
+streams_lyr <- paste0("streams_", sc$species, cfg$min_order)
+streams <- sf::st_read(net_gpkg, layer = streams_lyr, quiet = TRUE) |> sf::st_zm(drop = TRUE)
+if (!key %in% setdiff(names(streams), attr(streams, "sf_column"))) {
+  stop("attribute_by '", key, "' is not a column of ", streams_lyr, call. = FALSE)
+}
+valleys <- terra::rast(tif)
+message("Area: ", area, " | scenario: ", scenario, " | key: ", key,
+        " | ", length(unique(streams[[key]])), " groups | ", nrow(streams), " segments")
+
+# The DEM must be the same one the delineation came from, so it is fetched the same way step 2
+# fetches it (fl_dem_aoi over the streams + the scenario's max_width buffer). Thresholds come from
+# the scenario ROW, not defaults, so the attribution matches the delineation it is describing.
+buf <- sc$max_width
+message("Fetching MRDEM-30 for the network + ", buf, " m buffer ...")
+dem <- flooded::fl_dem_aoi(streams, buffer = buf, target_crs = sf::st_crs(streams))
+
+message("Attributing ", scenario, " by '", key, "' ...")
+attributed <- flooded::fl_valley_attribute(
+  valleys, streams, group = key, dem = dem,
+  max_width = sc$max_width, cost_threshold = sc$cost_threshold)
+attributed$wsg <- cfg$watershed_group; attributed$species <- sc$species
+attributed$scenario <- scenario
+
+# Carried label (#48): grouping on an opaque key is complete but unreadable in the field. Attach the
+# name when the key maps cleanly to one; refuse rather than mislabel when it does not.
+label_col <- "gnis_name"
+if (!identical(key, label_col) && label_col %in% names(streams)) {
+  lut <- unique(sf::st_drop_geometry(streams)[, c(key, label_col)])
+  lut <- lut[!is.na(lut[[label_col]]), , drop = FALSE]
+  n_per <- tapply(lut[[label_col]], lut[[key]], function(x) length(unique(x)))
+  if (any(n_per > 1)) {
+    message("  Label: skipped -- ", sum(n_per > 1), " key(s) carry more than one ", label_col)
+  } else {
+    lut <- lut[!duplicated(lut[[key]]), , drop = FALSE]
+    attributed[[label_col]] <- lut[[label_col]][match(attributed[[key]], lut[[key]])]
+    message("  Label: ", sum(!is.na(attributed[[label_col]])), " of ", nrow(attributed),
+            " groups carry a ", label_col)
+  }
+}
+attr_lyr <- paste0(scenario, "_by_", key)
+sf::st_write(attributed, fp_gpkg, layer = attr_lyr,
+             append = file.exists(fp_gpkg), delete_layer = TRUE, quiet = TRUE)
+fb <- attr(attributed, "fl_fallback_cells")
+message("  Wrote ", attr_lyr, " (", nrow(attributed), " groups",
+        if (!is.null(fb)) paste0("; ", fb, " fallback cells") else "", ")")
+
+# --- Bridge (#54), from the transition layer already on disk ---
+t_lyr <- if (file.exists(lc_gpkg))
+  grep(paste0("^transition_", scenario, "_[0-9]{4}_[0-9]{4}$"),
+       sf::st_layers(lc_gpkg)$name, value = TRUE) else character(0)
+if (!length(t_lyr)) {
+  message("  No transition layer for ", scenario, " -- bridge skipped (run step 3 to create it).")
+} else {
+  tp  <- sf::st_read(lc_gpkg, layer = t_lyr[1], quiet = TRUE)
+  # patch_id is per-SUB-BASIN, not global (see 03_lulc_classify.R). Key on the pair.
+  pat <- tp[, c("patch_id", "name_basin", "area_ha")]
+  wc  <- attributed[, key]
+  if (sf::st_crs(wc) != sf::st_crs(pat)) wc <- sf::st_transform(wc, sf::st_crs(pat))
+  inter <- suppressWarnings(sf::st_intersection(pat, wc))
+  ov <- as.numeric(sf::st_area(inter)) / 1e4
+  bridge <- data.frame(patch_id = inter$patch_id, name_basin = inter$name_basin, k = inter[[key]],
+                       overlap_ha = round(ov, 4),
+                       overlap_frac = round(pmin(1, ov / inter$area_ha), 4),
+                       wsg = cfg$watershed_group, species = sc$species, scenario = scenario,
+                       stringsAsFactors = FALSE)
+  names(bridge)[names(bridge) == "k"] <- key
+  bridge <- bridge[bridge$overlap_ha > 0, , drop = FALSE]
+  # Only apportion_weight is additive -- overlap_frac sums past 1 because the rows overlap (#54).
+  pk <- paste(bridge$name_basin, bridge$patch_id, sep = "\u00a6")
+  tot <- tapply(bridge$overlap_ha, pk, sum)
+  bridge$apportion_weight <- round(bridge$overlap_ha / tot[pk], 4)
+  b_lyr <- sub("^transition_", "patch_watercourse_", t_lyr[1])
+  sf::st_write(bridge, lc_gpkg, layer = b_lyr,
+               append = file.exists(lc_gpkg), delete_layer = TRUE, quiet = TRUE)
+  u <- tapply(bridge$overlap_frac, pk, max)
+  message("  Wrote ", b_lyr, " (", nrow(bridge), " pairs; union coverage ",
+          sprintf("%.3f", mean(u)), ")")
+}
+message("Done: ", area, "/", scenario, " -- delineation and transition layers untouched.")

--- a/scripts/floodplain_lcc/bridge-check.R
+++ b/scripts/floodplain_lcc/bridge-check.R
@@ -30,8 +30,18 @@ if (!b_lyr %in% lyrs)     stop("no bridge layer ", b_lyr, " -- run step 3 with a
 
 tp <- sf::st_read(lc, layer = t_lyr, quiet = TRUE)
 br <- sf::st_read(lc, layer = b_lyr, quiet = TRUE)
-key <- setdiff(names(br), c("patch_id","overlap_ha","overlap_frac","apportion_weight",
+key <- setdiff(names(br), c("patch_id","name_basin","overlap_ha","overlap_frac","apportion_weight",
                             "wsg","species","scenario"))
+# patch_id is per-sub-basin. Join on the PAIR or a multi-sub-basin area silently mis-reconciles:
+# match() takes the first row sharing an id, so a patch in basin A is credited basin B's area.
+# Older bridges predate the name_basin column; fall back so the check still runs against them.
+# Decide the scheme ONCE, from the bridge (the older artifact), and apply it to both sides. Deciding
+# per object is the bug it looks like a fix for: the transition layer always carries name_basin while
+# a pre-fix bridge does not, so the two sides key differently and match nothing.
+use_basin <- "name_basin" %in% names(br)
+pk_of <- function(x) if (use_basin)
+  paste(x$name_basin, x$patch_id, sep = "\u00a6") else as.character(x$patch_id)
+tp_pk <- NULL; br_pk <- NULL
 message("Area: ", area, " | ", t_lyr, " (", nrow(tp), " patches) | ", b_lyr, " (", nrow(br),
         " pairs, key = ", key, ")")
 
@@ -43,28 +53,31 @@ ok <- function(label, cond, detail = "") {
 }
 
 # --- the invariant that makes apportionment meaningful ---
-w <- tapply(br$apportion_weight, br$patch_id, sum)
+tp_pk <- pk_of(tp); br_pk <- pk_of(br)
+w <- tapply(br$apportion_weight, br_pk, sum)
 ok("apportion_weight sums to 1 per patch", max(abs(w - 1)) < 0.01,
    sprintf("max deviation %.4f", max(abs(w - 1))))
 
 # --- reconciliation: the check that caught the original spec error ---
-tl  <- tp[tp$from_class == "Trees" & tp$to_class != "Trees", ]
-bl  <- br[br$patch_id %in% tl$patch_id, ]
-bl$loss <- tl$area_ha[match(bl$patch_id, tl$patch_id)]
+tl     <- tp[tp$from_class == "Trees" & tp$to_class != "Trees", ]
+tl_pk  <- pk_of(tl)
+keep   <- br_pk %in% tl_pk
+bl     <- br[keep, ]; bl_pk <- br_pk[keep]
+bl$loss <- tl$area_ha[match(bl_pk, tl_pk)]
 tot <- sum(tl$area_ha); ap <- sum(bl$loss * bl$apportion_weight)
 ok("apportioned tree loss reconciles to the ungrouped total",
    abs(ap - tot) / tot < 0.005, sprintf("%.2f vs %.2f ha (%.3f%%)", ap, tot, 100*(ap-tot)/tot))
 
 # overlap_frac must NOT be usable as a weight -- if it ever sums to 1 the two columns have been
 # conflated somewhere upstream and the distinction this table exists to make has been lost.
-f <- mean(tapply(br$overlap_frac, br$patch_id, sum))
+f <- mean(tapply(br$overlap_frac, br_pk, sum))
 ok("overlap_frac is distinct from apportion_weight (sums > 1, as the rows overlap)", f > 1.05,
    sprintf("mean per-patch sum %.3f", f))
 
 # --- union coverage: how much of a patch any watercourse reaches ---
-u <- tapply(br$overlap_frac, br$patch_id, max)
+u <- tapply(br$overlap_frac, br_pk, max)
 ok("union coverage >= 0.90 mean", mean(u) >= 0.90, sprintf("%.4f", mean(u)))
-unbridged <- sum(!tp$patch_id %in% br$patch_id)
+unbridged <- sum(!tp_pk %in% br_pk)
 ok("few patches reach no watercourse at all", unbridged / nrow(tp) < 0.01,
    paste(unbridged, "of", nrow(tp)))
 


### PR DESCRIPTION
## Summary

Remodels 7 areas under `flooded` 0.5.0, points the pipeline at link's rebuilt `fresh` network, and
fixes a key bug the remodel exposed.

**Why the remodel was necessary, not routine.** flooded 0.5.0 fixed a bankfull regression fed
hectares where Hall et al. specify km2 and mm where they specify cm/yr -- bankfull width **8.22x**
and depth **3.59x** too large on **every run the package ever did**. `ff04` was delineating ~14.4x
bankfull depth against Hall's field-validated 3. Every floodplain from 0.4.1 or earlier is
over-mapped.

## The parity contract is re-baselined, not adjusted

| | old (0.4.0) | new | retained |
|---|---|---|---|
| neexdzii network coho-3 | 678.2 km | **673.5 km** | 99.3% |
| neexdzii `co_ff04` | 171.0 km2 | **142.8 km2** | **83.5%** |
| neexdzii tree loss | 943.13 ha | **770.0 ha** | — |
| morr `co_ff04` | 411.1 km2 | **357.7** | 87.0% |
| morr `ch_ff06` | 432.4 km2 | **371.6** | 85.9% |

The old numbers were produced by code now known wrong, so there was nothing correct left to verify a
remodel against — recorded as a fresh contract rather than a delta.

**It corroborates independently:** neexdzii retains 83.5%; flooded's own NEWS reports **84.7%** for
Parsnip on MRDEM-30. Different watershed, same DEM, within 1.2 points. Two variables moved together
(flooded *and* the network switch), so this is stated rather than implied — but the network moved
0.7% against the floodplain's 16.5%, so the bankfull fix dominates.

## Network source

`network_source: fresh` across skeena / skeena_ch / fraser / peace. link rebuilt province-wide into
`fresh` on 2026-08-31/09-01; the per-WSG schemas hold July networks and were untouched.

Provenance is **per-WSG rows in `fresh.log`** keyed by `watershed_group_code`, not log tables inside
each persist schema. I looked for the latter, found none, and reported "no provenance" — wrong.
`link::lnk_log_read(conn, cfg, aoi = "<WSG>")` is authoritative and answers in one call. All four
target WSGs verified **completed** (`date_end` non-null, not merely present), one run each,
`config_drift = FALSE`, shared `config_hash`. The region files now carry that lesson so the wrong
turn is not repeated.

**Guard caveat recorded:** the freshness guard compares grabbed km against `fresh.streams_vw_bcfp`,
so grabbing *from* `fresh` compares a schema to a view over itself. Observed: `2206 km vs bcfp 2206
km = 0.0% dev`. It passes and verifies nothing.

## The bug the remodel exposed

`patch_id` is numbered **per sub-basin**, not globally. Every whole-WSG area has one sub-basin, so it
was observably unique in all five that had been run; neexdzii (13 sub-basins) has 2032 rows and 1973
distinct ids. Grouping on it alone mis-apportioned by **6%**.

It was findable because the failure was *contradictory*: the same run reported "weights sum to 1",
"0 unbridged patches", and a 6% shortfall — three things that cannot all be true.

Fixed in all three places that key on it; the bridge now carries `name_basin`. **The first
backward-compat attempt was itself the bug** — choosing the key scheme per object gave the
transition layer (always has `name_basin`) and a pre-fix bridge (does not) different schemes, so
they matched nothing and all five whole-WSG areas reported 0 bridged patches. Decided once now, from
the bridge, applied to both sides.

## `attribute_tag.R`

Step 2 already saves `floodplain_<scenario>.tif`, so adding per-watercourse attribution never needed
a re-delineation — the expensive part. `fire_tag.R`'s shape: re-derive one product from what is on
disk. ~15-25 min per area instead of hours. Backfilled neexdzii, necr, pars, kisp.

## Test plan

- [x] 7 remodel runs, all `rc=0`, **0 error markers**, outputs verified rewritten against a run-start
      marker rather than trusting exit codes
- [x] `bridge-check.R` **PASS on all six** areas with a bridge
- [x] `region_config-check.R`, `gpkg_determinism-check.R` PASS
- [x] Existing whole-WSG bridges migrated by join (6 layers, 67,151 rows, **0 NA**) rather than
      re-running attribution — they were numerically correct, only missing the column

## Known gaps, filed not fixed

- **#59** — 13 areas still flooded 0.4.0. Publishing now yields a catalogue whose items cannot be
  compared to each other. **Decide before republishing.**
- **#60** — README regional totals are both over-mapped *and* summed rather than unioned
- **#51** — `lnk_stamp` records the version doing the grabbing, not the one that built the network
  (0.47.3 vs the 0.47.2 in `fresh.log`). Concrete instance now exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACm6wqpA4jg8qFvXjdPeYh
